### PR TITLE
Options parameter on putFileContents()

### DIFF
--- a/source/adapter/put.js
+++ b/source/adapter/put.js
@@ -11,13 +11,14 @@ module.exports = {
             .then(responseHandlers.handleResponseCode);
     },
 
-    putFileContents: function putFileContents(url, filePath, data) {
+    putFileContents: function putFileContents(url, filePath, data, options) {
+        //Set default headers
+        options.headers["Content-Type"] = "application/octet-stream";
+        options.headers["Content-Length"] = data.length;
+
         return fetch(url + filePath, {
                 method: "PUT",
-                headers: {
-                    "Content-Type": "application/octet-stream",
-                    "Content-Length": data.length
-                },
+                headers: options.headers,
                 body: data
             })
             .then(responseHandlers.handleResponseCode);

--- a/source/clientFactory.js
+++ b/source/clientFactory.js
@@ -37,14 +37,14 @@ module.exports = {
                 return alterAdapter.moveItem(__url, remotePath, targetRemotePath);
             },
 
-            putFileContents: function putFileContents(remoteFilename, format, data) {
+            putFileContents: function putFileContents(remoteFilename, format, data, options) {
                 format = format || "binary";
                 if (["binary", "text"].indexOf(format) < 0) {
                     throw new Error("Unknown format");
                 }
                 return (format === "text") ?
                     putAdapter.putTextContents(__url, remoteFilename, data) :
-                    putAdapter.putFileContents(__url, remoteFilename, data);
+                    putAdapter.putFileContents(__url, remoteFilename, data, options);
             },
 
             stat: function stat(remotePath) {


### PR DESCRIPTION
added options parameter to putFileContents(). This allows the user to set custom headers and additional parameter for later on (eg. OAuth).

Up to now i ignored the text variant of putFileContents(). But this could be enhanced as well. 
E.g for options variable:

 var options = {
                    "headers": {
                        "custom-header": "custom property",
"custom-header2": "custom property2"
                    }
                }

Feel free to contact me.

Cheers