### PR TITLE
Changed queryString.escape to queryString.stringify

### DIFF
--- a/source/url.js
+++ b/source/url.js
@@ -6,7 +6,7 @@ module.exports = {
         return (username && username.length > 0) ?
             url.replace(
                 /(https?:\/\/)/i,
-                "$1" + queryString.escape(username) + ":" + queryString.escape(password) + "@"
+                "$1" + queryString.stringify(username) + ":" + queryString.stringify(password) + "@"
             ) : url;
     },
 


### PR DESCRIPTION
I think this might be a broserify related problem, but while using webdav with broswerify i ran into the problem that the created querystring object did not have a escape method but only a queryString.stringify method.
I was wondering if this change might be taken upstream or weather this would produce problems