### PR TITLE
Check double slash

### DIFF
--- a/source/adapter/parse.js
+++ b/source/adapter/parse.js
@@ -60,7 +60,7 @@ function processDirectoryResult(dirPath, dirResult, targetOnly) {
             // skip self or only self
             return;
         }
-        filename = "/" + filename;
+        filename = path.posix.normalize("/" + filename);
         var item = {
                 filename: filename,
                 basename: path.basename(filename),


### PR DESCRIPTION
Make sure it won't add double slash that will make path.basename return nothing.