### PR TITLE
Add support for window.fetch

### DIFF
--- a/source/adapter/alter.js
+++ b/source/adapter/alter.js
@@ -1,7 +1,7 @@
-var fetch = require("node-fetch"),
-    deepmerge = require("deepmerge");
+var deepmerge = require("deepmerge");
 
-var responseHandlers = require("./response.js");
+var responseHandlers = require("./response.js"),
+    fetch = require("./request.js");
 
 module.exports = {
 

--- a/source/adapter/get.js
+++ b/source/adapter/get.js
@@ -1,8 +1,8 @@
-var fetch = require("node-fetch"),
-    xml2js = require("xml2js"),
+var xml2js = require("xml2js"),
     deepmerge = require("deepmerge");
 
-var parsing = require("./parse.js"),
+var fetch = require("./request.js"),
+    parsing = require("./parse.js"),
     responseHandlers = require("./response.js");
 
 module.exports = {

--- a/source/adapter/put.js
+++ b/source/adapter/put.js
@@ -1,7 +1,7 @@
-var fetch = require("node-fetch");
 var deepmerge = require("deepmerge");
 
-var responseHandlers = require("./response.js");
+var responseHandlers = require("./response.js"),
+    fetch = require("./request.js");
 
 function getPutContentsDefaults() {
     return {

--- a/source/adapter/request.js
+++ b/source/adapter/request.js
@@ -1,0 +1,10 @@
+var nodeFetch = require("node-fetch");
+
+var fetch = nodeFetch;
+if (typeof window === "object" && typeof window.fetch === "function") {
+    fetch = window.fetch;
+}
+
+module.exports = function request(url, options) {
+    return fetch(url, options);
+};


### PR DESCRIPTION
Currently the webpack'd copy in browsers uses XHRs to make the DAV requests, which uses cookies and causes sessions to lock on owncloud. Using native fetch fixes this by not sending cookies by default.

Fixes #18 