### PR TITLE
add http status code to the thrown exception.

### DIFF
--- a/source/adapter/response.js
+++ b/source/adapter/response.js
@@ -3,7 +3,9 @@ module.exports = {
     handleResponseCode: function(response) {
         var status = parseInt(response.status, 10);
         if (status >= 400) {
-            throw new Error("Invalid response: " + status + " " + response.statusText);
+            var err = new Error("Invalid response: " + status + " " + response.statusText);
+            err.status = status;
+            throw err;
         }
         return response;
     }


### PR DESCRIPTION
easy way to add some information to the thrown exception.
More elegant would be a custom error class, but this gets the job done quite nicely, too. This is related to
https://github.com/perry-mitchell/webdav-fs/issues/38 and https://github.com/perry-mitchell/webdav-client/issues/4
