### PR TITLE
Make ArrayBuffer fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ client
     });
 ```
 
+**Important**: When running on Node, `node-fetch` is used as the default fetch library. `node-fetch` provides the `.buffer()` method for responses, which returns a `Buffer` instance, but other libraries (and standard `fetch`) do not. When the `buffer` method is not available, this library will attempt to use `.arrayBuffer`. It is your responsibility to handle the output and any required conversion. The [`arraybuffer-to-buffer`](https://www.npmjs.com/package/arraybuffer-to-buffer) library makes it easy to convert back to a `Buffer` if you require it.
+
 #### getFileStream(remotePath _[, options]_)
 Get a readable stream on a remote file. Returns a Promise that resolves with a readable stream instance.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,18 +289,6 @@
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
-    "arraybuffer-equal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer-equal/-/arraybuffer-equal-1.0.4.tgz",
-      "integrity": "sha1-OY2u/+WuO9sVFGGW10Hdc7Z0pXg=",
-      "dev": true
-    },
-    "arraybuffer-to-buffer": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer-to-buffer/-/arraybuffer-to-buffer-0.0.4.tgz",
-      "integrity": "sha1-LD+Oj01UNipcYWVJbyEXb3/ZZqY=",
-      "dev": true
-    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "xml2js": "~0.4.17"
   },
   "devDependencies": {
-    "arraybuffer-equal": "~1.0.4",
-    "arraybuffer-to-buffer": "0.0.4",
     "babel-cli": "~6.26.0",
     "babel-core": "~6.26.0",
     "babel-preset-env": "~1.6.1",

--- a/source/interface/getFile.js
+++ b/source/interface/getFile.js
@@ -8,7 +8,6 @@ const fetch = request.fetch;
 
 function getFileContentsBuffer(filePath, options) {
     return makeFileRequest(filePath, options).then(function(res) {
-        console.log(typeof res.buffer);
         return typeof res.buffer === "function" ? res.buffer() : res.arrayBuffer();
     });
 }

--- a/source/interface/getFile.js
+++ b/source/interface/getFile.js
@@ -8,7 +8,8 @@ const fetch = request.fetch;
 
 function getFileContentsBuffer(filePath, options) {
     return makeFileRequest(filePath, options).then(function(res) {
-        return res.arrayBuffer();
+        console.log(typeof res.buffer);
+        return typeof res.buffer === "function" ? res.buffer() : res.arrayBuffer();
     });
 }
 

--- a/source/request.js
+++ b/source/request.js
@@ -25,6 +25,7 @@ function encodePath(path) {
 }
 
 function request(url, options) {
+    console.log("REQ", fetchMethod);
     return fetchMethod(url, options);
 }
 

--- a/source/request.js
+++ b/source/request.js
@@ -25,7 +25,6 @@ function encodePath(path) {
 }
 
 function request(url, options) {
-    console.log("REQ", fetchMethod);
     return fetchMethod(url, options);
 }
 

--- a/test/specs/getFileContents.spec.js
+++ b/test/specs/getFileContents.spec.js
@@ -37,7 +37,7 @@ describe("getFileContents", function() {
         });
     });
 
-    it.only("uses .arrayBuffer() when .buffer() is not available", function() {
+    it("uses .arrayBuffer() when .buffer() is not available", function() {
         setFetchMethod(function fakeFetch() {
             return nodeFetch.apply(null, arguments).then(function(response) {
                 return {

--- a/test/specs/getFileContents.spec.js
+++ b/test/specs/getFileContents.spec.js
@@ -1,13 +1,15 @@
 const path = require("path");
 const fs = require("fs");
 const bufferEquals = require("buffer-equals");
-const arrayBufferToBuffer = require("arraybuffer-to-buffer");
+const nodeFetch = require("node-fetch");
+const setFetchMethod = require("../../dist/request.js").setFetchMethod;
 
 const SOURCE_BIN = path.resolve(__dirname, "../testContents/alrighty.jpg");
 const SOURCE_TXT = path.resolve(__dirname, "../testContents/text document.txt");
 
 describe("getFileContents", function() {
     beforeEach(function() {
+        setFetchMethod(); // use default
         this.client = createWebDAVClient(
             "http://localhost:9988/webdav/server",
             createWebDAVServer.test.username,
@@ -23,13 +25,29 @@ describe("getFileContents", function() {
     });
 
     it("reads a remote file into a buffer", function() {
-        return this.client
-            .getFileContents("/alrighty.jpg")
-            .then(arrayBufferToBuffer)
-            .then(function(bufferRemote) {
-                const bufferLocal = fs.readFileSync(SOURCE_BIN);
-                expect(bufferEquals(bufferRemote, bufferLocal)).to.be.true;
+        return this.client.getFileContents("/alrighty.jpg").then(function(bufferRemote) {
+            const bufferLocal = fs.readFileSync(SOURCE_BIN);
+            expect(bufferEquals(bufferRemote, bufferLocal)).to.be.true;
+        });
+    });
+
+    it("uses .buffer() when available", function() {
+        return this.client.getFileContents("/alrighty.jpg").then(res => {
+            expect(res).to.be.an.instanceof(Buffer);
+        });
+    });
+
+    it.only("uses .arrayBuffer() when .buffer() is not available", function() {
+        setFetchMethod(function fakeFetch() {
+            return nodeFetch.apply(null, arguments).then(function(response) {
+                return {
+                    arrayBuffer: response.arrayBuffer.bind(response)
+                };
             });
+        }); // use fixed
+        return this.client.getFileContents("/alrighty.jpg").then(res => {
+            expect(res).to.be.an.instanceof(ArrayBuffer);
+        });
     });
 
     it("reads a remote file into a string", function() {


### PR DESCRIPTION
Make the `.arrayBuffer` call secondary to `.buffer()`. Fixes #79.