### PR TITLE
Dir contents trailing slash bug

### DIFF
--- a/source/interface/directoryContents.js
+++ b/source/interface/directoryContents.js
@@ -14,7 +14,10 @@ const fetch = request.fetch;
 const getValueForKey = davTools.getValueForKey;
 const getSingleValue = davTools.getSingleValue;
 
-function getDirectoryContents(remotePath, options) {
+function getDirectoryContents(remotePathRaw, options) {
+    // Strip the ending slash
+    const remotePath = remotePathRaw.replace(/\/$/, "");
+    // Join the URL and path for the request
     const fetchURL = joinURL(options.remoteURL, encodePath(remotePath));
     const fetchOptions = {
         method: "PROPFIND",

--- a/test/specs/getDirectoryContents.spec.js
+++ b/test/specs/getDirectoryContents.spec.js
@@ -41,6 +41,13 @@ describe("getDirectoryContents", function() {
         });
     });
 
+    it("returns only expected results when using trailing slash", function() {
+        return this.client.getDirectoryContents("/webdav/").then(function(contents) {
+            const items = contents.map(item => item.filename).join(",");
+            expect(items).to.equal("/webdav/server");
+        });
+    });
+
     it("returns correct file results", function() {
         return this.client.getDirectoryContents("/").then(function(contents) {
             const sub1 = contents.find(function(item) {


### PR DESCRIPTION
Fix a bug where requesting paths like `/some/path/` using `getDirectoryContents` would show the parent directory in the output.