### PR TITLE
Move encode path of destination

### DIFF
--- a/source/interface/moveFile.js
+++ b/source/interface/moveFile.js
@@ -13,7 +13,7 @@ function moveFile(filename, destination, options) {
         method: "MOVE",
         headers: merge(
             {
-                Destination: joinURL(options.remoteURL, destination)
+                Destination: joinURL(options.remoteURL, encodePath(destination))
             },
             options.headers
         ),


### PR DESCRIPTION
Move fails with 400 on windows Webdav when ` ` sent instead of `%20`