### PR TITLE
support for depth header on propfind requests

### DIFF
--- a/source/interface/directoryContents.js
+++ b/source/interface/directoryContents.js
@@ -13,7 +13,7 @@ function getDirectoryContents(remotePath, options) {
         method: "PROPFIND",
         headers: {
             Accept: "text/plain",
-            Depth: 1
+            Depth: options.depth || 1
         },
         responseType: "text"
     };


### PR DESCRIPTION
#130 

I started to write tests for this feature but not sure how to go about that since I don't think the webdav-server library supports infinite depth requests.  
I use Apache ModDAV in production, with infinite propfinds enabled, and have successfully tested this feature there.
Thanks