### PR TITLE
Add props to detailed responses (#134)

### DIFF
--- a/source/interface/directoryContents.js
+++ b/source/interface/directoryContents.js
@@ -26,11 +26,11 @@ function getDirectoryContents(remotePath, options) {
             return res.data;
         })
         .then(parseXML)
-        .then(result => getDirectoryFiles(result, options.remotePath, remotePath))
+        .then(result => getDirectoryFiles(result, options.remotePath, remotePath, options.details))
         .then(files => processResponsePayload(response, files, options.details));
 }
 
-function getDirectoryFiles(result, serverBasePath, requestPath) {
+function getDirectoryFiles(result, serverBasePath, requestPath, isDetailed = false) {
     const remoteTargetPath = pathPosix.join(serverBasePath, requestPath, "/");
     const serverBase = pathPosix.join(serverBasePath, "/");
     // Extract the response items (directory contents)
@@ -55,7 +55,9 @@ function getDirectoryFiles(result, serverBasePath, requestPath) {
                 // Process the true full filename (minus the base server path)
                 const filename =
                     serverBase === "/" ? normalisePath(href) : normalisePath(pathPosix.relative(serverBase, href));
-                return propsToStat(props, filename);
+                const stat = propsToStat(props, filename);
+                if (isDetailed) stat.props = props;
+                return stat;
             })
     );
 }

--- a/source/interface/stat.js
+++ b/source/interface/stat.js
@@ -24,11 +24,11 @@ function getStat(filename, options) {
             return res.data;
         })
         .then(parseXML)
-        .then(xml => parseStat(xml, filename))
+        .then(xml => parseStat(xml, filename, options.details))
         .then(result => processResponsePayload(response, result, options.details));
 }
 
-function parseStat(result, filename) {
+function parseStat(result, filename, isDetailed = false) {
     let responseItem = null,
         multistatus;
     try {
@@ -43,7 +43,9 @@ function parseStat(result, filename) {
     const propStat = getSingleValue(getValueForKey("propstat", responseItem));
     const props = getSingleValue(getValueForKey("prop", propStat));
     const filePath = urlTools.normalisePath(filename);
-    return propsToStat(props, filePath);
+    const stat = propsToStat(props, filePath);
+    if (isDetailed) stat.props = props;
+    return stat;
 }
 
 module.exports = {

--- a/test/specs/getDirectoryContents.spec.js
+++ b/test/specs/getDirectoryContents.spec.js
@@ -35,6 +35,9 @@ describe("getDirectoryContents", function() {
             expect(details)
                 .to.have.property("headers")
                 .that.is.an("object");
+            expect(details.data[0])
+                .to.have.property("props")
+                .that.is.an("object");
         });
     });
 

--- a/test/specs/stat.spec.js
+++ b/test/specs/stat.spec.js
@@ -55,6 +55,9 @@ describe("stat", function() {
             expect(details)
                 .to.have.property("headers")
                 .that.is.an("object");
+            expect(details.data)
+                .to.have.property("props")
+                .that.is.an("object");
         });
     });
 });


### PR DESCRIPTION
When the option `details` is enabled, the stats of each WebDAV file and collection should contain the original props to allow the reading of addtional item information.

This fixes #134.

**Breaking Changes:** None

**New API:**
When the options contain `{ details: true }` the result data of `getDirectoryContents()` and `stat()` contains a new `props` object next to other stat-fields like `basename` and `filename`.

Example response:
```JSON
[
   {
      "filename":"/sub1",
      "basename":"sub1",
      "lastmod":"Sat, 19 Jan 2019 14:06:55 GMT",
      "size":0,
      "type":"directory",
      "props":{
         "D:getlastmodified":[
            "Sat, 19 Jan 2019 14:06:55 GMT"
         ],
         "D:lockdiscovery":[...],
         "D:supportedlock":[...],
         "D:creationdate":[
            "2019-01-19T14:06:55-01:00"
         ],
         "D:resourcetype":[...],
         "D:displayname":[
            "sub1"
         ],
         "D:getetag":[
            "\"ad26f60f92b318bfe4e833069bed23d6\""
         ]
      }
   },
   ...
]
```

**TODO:**
- [ ] Maybe a new unit test should be added to check if new custom properties are received. But I didn't find an easy way to do this using the node `webdav-server` library.