### PR TITLE
Support uploading bigger files with createWriteStream #144

### DIFF
--- a/source/request.js
+++ b/source/request.js
@@ -47,6 +47,9 @@ function prepareRequestOptions(requestOptions, methodOptions) {
     if (typeof methodOptions.withCredentials === "boolean") {
         requestOptions.withCredentials = methodOptions.withCredentials;
     }
+    if (methodOptions.maxContentLength) {
+        requestOptions.maxContentLength = methodOptions.maxContentLength;
+    }
 }
 
 /**


### PR DESCRIPTION
Added `maxContentLength` to prepareRequestOptions to pass along to `axios`. Solves https://github.com/perry-mitchell/webdav-client/issues/144