### PR TITLE
Support additional body in requests

### DIFF
--- a/source/request.js
+++ b/source/request.js
@@ -26,7 +26,7 @@ function encodePath(path) {
  * @property {Object=} httpsAgent - HTTPS agent instance
  * @property {Object=} headers - Set additional request headers
  * @property {Boolean=} withCredentials - Set whether or not credentials should
- * @property {Object|String|*=} body - Set additional body
+ * @property {Object|String|*=} data - Set additional body
  *  be included with the request. Defaults to value used by axios.
  */
 
@@ -42,8 +42,8 @@ function prepareRequestOptions(requestOptions, methodOptions) {
     if (methodOptions.httpsAgent) {
         requestOptions.httpsAgent = methodOptions.httpsAgent;
     }
-    if (methodOptions.body) {
-        requestOptions.body = methodOptions.body;
+    if (methodOptions.data) {
+        requestOptions.data = methodOptions.data;
     }
     if (methodOptions.headers && typeof methodOptions.headers === "object") {
         requestOptions.headers = merge(requestOptions.headers || {}, methodOptions.headers);
@@ -70,7 +70,7 @@ function prepareRequestOptions(requestOptions, methodOptions) {
  * @property {Object=} headers - Headers to set on the request
  * @property {Object=} httpAgent - A HTTP agent instance
  * @property {Object=} httpsAgent - A HTTPS agent interface
- * @property {Object|String|*=} body - Body data for the request
+ * @property {Object|String|*=} data - Body data for the request
  */
 
 /**

--- a/source/request.js
+++ b/source/request.js
@@ -26,6 +26,7 @@ function encodePath(path) {
  * @property {Object=} httpsAgent - HTTPS agent instance
  * @property {Object=} headers - Set additional request headers
  * @property {Boolean=} withCredentials - Set whether or not credentials should
+ * @property {Object|String|*=} body - Set additional body
  *  be included with the request. Defaults to value used by axios.
  */
 
@@ -40,6 +41,9 @@ function prepareRequestOptions(requestOptions, methodOptions) {
     }
     if (methodOptions.httpsAgent) {
         requestOptions.httpsAgent = methodOptions.httpsAgent;
+    }
+    if (methodOptions.body) {
+        requestOptions.body = methodOptions.body;
     }
     if (methodOptions.headers && typeof methodOptions.headers === "object") {
         requestOptions.headers = merge(requestOptions.headers || {}, methodOptions.headers);


### PR DESCRIPTION
This PR make it possible to send requests with the `body` parameter to WebDav server.

The `prepareRequestOptions` function ignores the `body` parameter in methodOptions.
So, this PR modifies codes to avoid ignoring the parameter and makes options compatible with `axios` options by renaming `body` to `data`.

Please review this.
