### PR TITLE
Forward cancelToken to request options

### DIFF
--- a/source/request.js
+++ b/source/request.js
@@ -51,6 +51,9 @@ function prepareRequestOptions(requestOptions, methodOptions) {
     if (typeof methodOptions.withCredentials === "boolean") {
         requestOptions.withCredentials = methodOptions.withCredentials;
     }
+    if (methodOptions.cancelToken && typeof methodOptions.cancelToken === "object") {
+        requestOptions.cancelToken = merge(requestOptions.cancelToken || {}, methodOptions.cancelToken);
+    }
     if (methodOptions.maxContentLength) {
         requestOptions.maxContentLength = methodOptions.maxContentLength;
     }


### PR DESCRIPTION
Fix #179

Though I cannot catch the error properly.
I can when using `axios.get`, but I cannot with the webdav lib.

Axios is outputing this in the console:
![Capture d’écran_2019-10-29_15-38-48](https://user-images.githubusercontent.com/14975046/67777605-443b8080-fa62-11e9-83c5-4d49636b3c2c.png)
But webdav is throwing
![Capture d’écran_2019-10-29_15-39-05](https://user-images.githubusercontent.com/14975046/67777630-4b628e80-fa62-11e9-8bc2-34291287e4e3.png)

