### PR TITLE
provide callback for writeStream

### DIFF
--- a/source/factory.js
+++ b/source/factory.js
@@ -174,19 +174,20 @@ function createClient(remoteURL, opts = {}) {
          * Create a writeable stream to a remote file
          * @param {String} remoteFilename The file to write to
          * @param {PutOptions=} options Options for the request
+         * @param {Function} callback Callback when response is received
          * @memberof ClientInterface
          * @returns {Writeable} A writeable stream
          * @example
          *      const remote = client.createWriteStream("/data.zip");
          *      fs.createReadStream("~/myData.zip").pipe(remote);
          */
-        createWriteStream: function createWriteStream(remoteFilename, options) {
+        createWriteStream: function createWriteStream(remoteFilename, options, callback) {
             if (typeof WEB !== "undefined" && WEB === true) {
                 throw new Error("createWriteStream not implemented in web environment");
             } else {
                 const createStream = require("./interface/createStream.js");
                 const createOptions = merge(runtimeOptions, options || {});
-                return createStream.createWriteStream(remoteFilename, createOptions);
+                return createStream.createWriteStream(remoteFilename, createOptions, callback);
             }
         },
 

--- a/source/factory.js
+++ b/source/factory.js
@@ -14,6 +14,8 @@ const copy = require("./interface/copyFile.js");
 const putFile = require("./interface/putFile.js");
 const stats = require("./interface/stat.js");
 
+const NOOP = () => {};
+
 /**
  * Client adapter
  * @typedef {Object} ClientInterface
@@ -174,14 +176,15 @@ function createClient(remoteURL, opts = {}) {
          * Create a writeable stream to a remote file
          * @param {String} remoteFilename The file to write to
          * @param {PutOptions=} options Options for the request
-         * @param {Function} callback Callback when response is received
+         * @param {Function=} callback Optional callback to fire
+         *  once the request has finished
          * @memberof ClientInterface
          * @returns {Writeable} A writeable stream
          * @example
          *      const remote = client.createWriteStream("/data.zip");
          *      fs.createReadStream("~/myData.zip").pipe(remote);
          */
-        createWriteStream: function createWriteStream(remoteFilename, options, callback) {
+        createWriteStream: function createWriteStream(remoteFilename, options, callback = NOOP) {
             if (typeof WEB !== "undefined" && WEB === true) {
                 throw new Error("createWriteStream not implemented in web environment");
             } else {

--- a/source/interface/createStream.js
+++ b/source/interface/createStream.js
@@ -15,7 +15,7 @@ function createReadStream(filePath, options) {
     return outStream;
 }
 
-function createWriteStream(filePath, options) {
+function createWriteStream(filePath, options, callback) {
     const Stream = require("stream");
     const PassThroughStream = Stream.PassThrough;
     const writeStream = new PassThroughStream();
@@ -30,8 +30,13 @@ function createWriteStream(filePath, options) {
         data: writeStream
     };
     prepareRequestOptions(requestOptions, options);
+
+    if (!callback || typeof callback !== "function") {
+        callback=responseHandlers.handleResponseCode;
+    }
+
     request(requestOptions)
-        .then(responseHandlers.handleResponseCode)
+        .then(callback)
         .catch(err => {
             writeStream.emit("error", err);
         });


### PR DESCRIPTION
Currently there's no way to see if the request sent by writeStream (for uploading a file) is finished or not. The writeStream.on("finish") event is fired before the request is complement since the request itself is synchronize. This change adds a callback option when creating writeStream so that the callback is executed when the request sent by the writeStream is finished sending data