### PR TITLE
Fix getDirectoryContents for directories with & in name

### DIFF
--- a/source/interface/directoryContents.js
+++ b/source/interface/directoryContents.js
@@ -30,7 +30,6 @@ function getDirectoryContents(remotePath, options) {
 }
 
 function getDirectoryFiles(result, serverBasePath, requestPath, isDetailed = false) {
-    const remoteTargetPath = pathPosix.join(serverBasePath, requestPath, "/");
     const serverBase = pathPosix.join(serverBasePath, "/");
     // Extract the response items (directory contents)
     const {
@@ -38,12 +37,6 @@ function getDirectoryFiles(result, serverBasePath, requestPath, isDetailed = fal
     } = result;
     return (
         responseItems
-            // Filter out the item pointing to the current directory (not needed)
-            .filter(item => {
-                let href = item.href;
-                href = pathPosix.join(normalisePath(normaliseHREF(href)), "/");
-                return href !== serverBase && href !== remoteTargetPath;
-            })
             // Map all items to a consistent output structure (results)
             .map(item => {
                 // HREF is the file path (in full)
@@ -57,6 +50,14 @@ function getDirectoryFiles(result, serverBasePath, requestPath, isDetailed = fal
                     serverBase === "/" ? normalisePath(href) : normalisePath(pathPosix.relative(serverBase, href));
                 return prepareFileFromProps(props, filename, isDetailed);
             })
+            // Filter out the item pointing to the current directory (not needed)
+            .filter(item =>
+                item.basename &&
+                (
+                    item.type === "file" ||
+                    item.filename !== requestPath.replace(/\/$/, "")
+                )
+            )
     );
 }
 

--- a/test/serverContents/with & in path/file.txt
+++ b/test/serverContents/with & in path/file.txt
@@ -1,0 +1,1 @@
+I am content with the contents

--- a/test/specs/getDirectoryContents.spec.js
+++ b/test/specs/getDirectoryContents.spec.js
@@ -100,6 +100,13 @@ describe("getDirectoryContents", function() {
         });
     });
 
+    it('returns only the directory contents for directory with & in name', function() {
+        return this.client.getDirectoryContents("/with & in path").then(function(contents) {
+            expect(contents).to.have.lengthOf(1);
+            expect(contents[0].basename).to.equal("file.txt");
+        });
+    });
+
     it("returns correct directory contents when path contains encoded sequences (issue #93)", function() {
         return this.client.getDirectoryContents("/two%20words").then(contents => {
             expect(contents).to.have.lengthOf(1);


### PR DESCRIPTION
Webdav servers turn & into &amp;amp; in their responses however the client
does not decode this entity.