### PR TITLE
Fix unnecessary excessive memory usage when uploading big files

### DIFF
--- a/source/interface/createStream.js
+++ b/source/interface/createStream.js
@@ -29,7 +29,8 @@ function createWriteStream(filePath, options, callback = NOOP) {
         url: joinURL(options.remoteURL, encodePath(filePath)),
         method: "PUT",
         headers,
-        data: writeStream
+        data: writeStream,
+        maxRedirects: 0
     };
     prepareRequestOptions(requestOptions, options);
     request(requestOptions)


### PR DESCRIPTION
When uploading a file the complete contents of the file is loaded in memory
just in case the request ends up with a redirect response and the request
has to be resent.

see https://github.com/axios/axios/issues/2783