### PR TITLE
Allow setting the option `maxBodyLength` on `putFileContents()`

### DIFF
--- a/source/factory.js
+++ b/source/factory.js
@@ -25,7 +25,8 @@ const NOOP = () => {};
  * Options for creating a resource
  * @typedef {UserOptions} PutOptions
  * @property {Boolean=} overwrite - Whether or not to overwrite existing files (default: true)
- * @property {Number=} maxContentLength - The maximum amount of bytes to upload (default: 10 MiB)
+ * @property {Number=} maxContentLength - The maximum amount of bytes to download (default: 10 MiB)
+ * @property {Number=} maxBodyLength - The maximum amount of bytes to upload (default: 10 MiB) (only in nodejs-environments)
  */
 
 /**

--- a/source/request.js
+++ b/source/request.js
@@ -71,6 +71,9 @@ function prepareRequestOptions(requestOptions, methodOptions) {
     if (methodOptions.maxContentLength) {
         requestOptions.maxContentLength = methodOptions.maxContentLength;
     }
+    if (methodOptions.maxBodyLength) {
+        requestOptions.maxBodyLength = methodOptions.maxBodyLength;
+    }
     if (methodOptions.onUploadProgress && typeof methodOptions.onUploadProgress === "function") {
         requestOptions.onUploadProgress = methodOptions.onUploadProgress;
     }


### PR DESCRIPTION
Hi there,

I recently ran into a problem when uploading big files to a nextcloud instance. Axios would complain

```
Error [ERR_FR_MAX_BODY_LENGTH_EXCEEDED]: Request body larger than maxBodyLength limit
```

This PR allows using the option `maxBodyLength` directly on the `putFileContents` method of this webdav client. One would use it for example like this:

```
await client.putFileContents(
  "/remote/file", 
  fs.readFileSync('./a-big-file'), 
  { 
    'maxBodyLength': Infinity,
  }
);
```

To achieve this, the option is simply passed through to axios which in turn will pass it on to `follow-redirects`, which is it's default backend in nodejs environments. It did in fact solve the issue in my project.

Until earlier this year, axios would have used the value of `maxContentLength` to set the value of `maxBodyLength`, but at some point someone found out that those two are in fact not the same and changed that behaviour, which I assume broke functionality of `webdav-client` as well. In my understanding, `maxContentLength` is now supposed to be used only for setting the limit of the *respnse* size, while `maxBodyLength` defines the limit of the *request* body size. See this issue for reference: https://github.com/axios/axios/issues/2696

Let me know what you think!

Best,
Benjamin.