### PR TITLE
putFileContents: overwrite: handle 412 response

### DIFF
--- a/source/operations/copyFile.ts
+++ b/source/operations/copyFile.ts
@@ -18,5 +18,5 @@ export async function copyFile(
         }
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
 }

--- a/source/operations/createDirectory.ts
+++ b/source/operations/createDirectory.ts
@@ -14,5 +14,5 @@ export async function createDirectory(
         method: "MKCOL"
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
 }

--- a/source/operations/createStream.ts
+++ b/source/operations/createStream.ts
@@ -55,7 +55,7 @@ export function createWriteStream(
             setTimeout(callback, 0);
             return response;
         })
-        .then(handleResponseCode)
+        .then(response => handleResponseCode(context, response))
         .catch(err => {
             writeStream.emit("error", err);
         });
@@ -82,6 +82,6 @@ async function getFileStream(
         responseType: "stream"
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
     return response.data as Stream.Readable;
 }

--- a/source/operations/customRequest.ts
+++ b/source/operations/customRequest.ts
@@ -14,6 +14,6 @@ export async function customRequest(
     }
     const finalOptions = prepareRequestOptions(requestOptions, context, {});
     const response = await request(finalOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
     return response;
 }

--- a/source/operations/deleteFile.ts
+++ b/source/operations/deleteFile.ts
@@ -14,5 +14,5 @@ export async function deleteFile(
         method: "DELETE"
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
 }

--- a/source/operations/directoryContents.ts
+++ b/source/operations/directoryContents.ts
@@ -27,7 +27,7 @@ export async function getDirectoryContents(
         responseType: "text"
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
     const davResp = await parseXML(response.data as string);
     let files = getDirectoryFiles(davResp, context.remotePath, remotePath, options.details);
     if (options.glob) {

--- a/source/operations/exists.ts
+++ b/source/operations/exists.ts
@@ -10,7 +10,7 @@ export async function exists(
         await getStat(context, remotePath, options);
         return true;
     } catch (err) {
-        if (err.response && err.response.status === 404) {
+        if (err.status === 404) {
             return false;
         }
         throw err;

--- a/source/operations/getFileContents.ts
+++ b/source/operations/getFileContents.ts
@@ -42,7 +42,7 @@ async function getFileContentsBuffer(
         responseType: "arraybuffer"
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
     return processResponsePayload(response, response.data as BufferLike, options.details);
 }
 
@@ -57,7 +57,7 @@ async function getFileContentsString(
         responseType: "text"
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
     return processResponsePayload(response, response.data as string, options.details);
 }
 

--- a/source/operations/getQuota.ts
+++ b/source/operations/getQuota.ts
@@ -19,7 +19,7 @@ export async function getQuota(
         responseType: "text"
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
     const result = await parseXML(response.data as string);
     const quota = parseQuota(result);
     return processResponsePayload(response, quota, options.details);

--- a/source/operations/moveFile.ts
+++ b/source/operations/moveFile.ts
@@ -18,5 +18,5 @@ export async function moveFile(
         }
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
 }

--- a/source/operations/stat.ts
+++ b/source/operations/stat.ts
@@ -21,7 +21,7 @@ export async function getStat(
         responseType: "text"
     }, context, options);
     const response = await request(requestOptions);
-    handleResponseCode(response);
+    handleResponseCode(context, response);
     const result = await parseXML(response.data as string);
     const stat = parseStat(result, filename, isDetailed);
     return processResponsePayload(response, stat, isDetailed);

--- a/source/request.ts
+++ b/source/request.ts
@@ -35,7 +35,7 @@ export function prepareRequestOptions(
     }
     if (context.digest) {
         finalOptions._digest = context.digest;
-        finalOptions.validateStatus = status => (status >= 200 && status < 300) || status == 401;
+        // finalOptions.validateStatus = status => (status >= 200 && status < 300) || status == 401;
     }
     if (typeof context.withCredentials === "boolean") {
         finalOptions.withCredentials = context.withCredentials;
@@ -46,6 +46,8 @@ export function prepareRequestOptions(
     if (context.maxBodyLength) {
         finalOptions.maxBodyLength = context.maxBodyLength;
     }
+    // Take full control of all response status codes
+    finalOptions.validateStatus = () => true;
     return finalOptions;
 }
 

--- a/source/response.ts
+++ b/source/response.ts
@@ -1,11 +1,11 @@
 import minimatch from "minimatch";
-import { FileStat, Response, ResponseDataDetailed, WebDAVClientError } from "./types";
+import { FileStat, Response, ResponseDataDetailed, WebDAVClientContext, WebDAVClientError } from "./types";
 
-export function handleResponseCode(response: Response): Response {
+export function handleResponseCode(context: WebDAVClientContext, response: Response): Response {
     const status = response.status;
-    let err: WebDAVClientError;
+    if (status === 401 && context.digest) return response;
     if (status >= 400) {
-        err = new Error(`Invalid response: ${status} ${response.statusText}`) as WebDAVClientError;
+        const err: WebDAVClientError = new Error(`Invalid response: ${status} ${response.statusText}`) as WebDAVClientError;
         err.status = status;
         throw err;
     }

--- a/source/types.ts
+++ b/source/types.ts
@@ -200,7 +200,7 @@ export interface WebDAVClient {
     getHeaders: () => Headers;
     getQuota: (options?: GetQuotaOptions) => Promise<DiskQuota | null | ResponseDataDetailed<DiskQuota | null>>;
     moveFile: (filename: string, destinationFilename: string) => Promise<void>;
-    putFileContents: (filename: string, data: string | BufferLike | Stream.Readable, options?: PutFileContentsOptions) => Promise<void>;
+    putFileContents: (filename: string, data: string | BufferLike | Stream.Readable, options?: PutFileContentsOptions) => Promise<boolean>;
     setHeaders: (headers: Headers) => void;
     stat: (path: string, options?: StatOptions) => Promise<FileStat | ResponseDataDetailed<FileStat>>;
 }


### PR DESCRIPTION
Handles the 412 response code for when `{ overwrite: false }` on an existing remote file. Closes #203 