### PR TITLE
Body/data override

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ Most WebDAV methods extend `WebDAVMethodOptions`, which allow setting things lik
 
 | Option            | Required  | Description                                   |
 |-------------------|-----------|-----------------------------------------------|
+| `data`            | No        | Optional body/data value to send in the request. This overrides the original body of the request, if applicable. |
 | `headers`         | No        | Optional headers object to apply to the request. These headers override all others, so be careful. |
 
 ### Common data structures

--- a/source/request.ts
+++ b/source/request.ts
@@ -27,6 +27,9 @@ export function prepareRequestOptions(
         (finalOptions.headers || {}),
         (userOptions.headers || {})
     );
+    if (typeof userOptions.data !== "undefined") {
+        finalOptions.data = userOptions.data;
+    }
     if (context.httpAgent) {
         finalOptions.httpAgent = context.httpAgent;
     }
@@ -35,7 +38,6 @@ export function prepareRequestOptions(
     }
     if (context.digest) {
         finalOptions._digest = context.digest;
-        // finalOptions.validateStatus = status => (status >= 200 && status < 300) || status == 401;
     }
     if (typeof context.withCredentials === "boolean") {
         finalOptions.withCredentials = context.withCredentials;

--- a/source/types.ts
+++ b/source/types.ts
@@ -240,5 +240,6 @@ export interface WebDAVClientOptions {
 }
 
 export interface WebDAVMethodOptions {
+    data?: RequestDataPayload;
     headers?: Headers;
 }

--- a/test/node/operations/stat.spec.js
+++ b/test/node/operations/stat.spec.js
@@ -99,5 +99,23 @@ describe("stat", function() {
                     .that.matches(/GMT$/);
             });
         });
+
+        it("allows requesting a custom set of properties", function() {
+            return this.client.stat(
+                "/alrighty.jpg",
+                {
+                    data: `<?xml version="1.0"?>
+                    <d:propfind xmlns:d="DAV:">
+                        <d:prop>
+                            <d:getlastmodified />
+                        </d:prop>
+                    </d:propfind>`,
+                    details: true
+                }
+            ).then(function(result) {
+                expect(result).to.have.nested.property("data.props").that.is.an("object");
+                expect(Object.keys(result.data.props)).to.deep.equal(["getlastmodified"]);
+            });
+        });
     });
 });


### PR DESCRIPTION
Allows the overriding of the body data in most requests. Useful for providing a list of props in stat/PROPFIND requests:

```
client.stat(
                "/alrighty.jpg",
                {
                    data: `<?xml version="1.0"?>
                    <d:propfind xmlns:d="DAV:">
                        <d:prop>
                            <d:getlastmodified />
                        </d:prop>
                    </d:propfind>`,
                    details: true
                }
            )
)
```

Closes #238