### PR TITLE
Add typescript definitions to web submodule

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "npm run clean && run-p build:node build:web",
     "build:node": "tsc",
-    "build:web": "webpack --mode production --config webpack.config.js",
+    "build:web": "webpack --mode production --config webpack.config.js && tsc --emitDeclarationOnly --outDir dist/web/",
     "clean": "rimraf dist web",
     "format": "prettier --write '{source,test}/**/*.js'",
-    "prepare:publish:web": "mkdirp ./web && mv ./dist/web/webdav.js ./web/index.js",
+    "prepare:publish:web": "cp -r ./dist/web ./web && mv ./web/webdav.js ./web/index.js",
     "prepublishOnly": "run-s build prepare:publish:web",
     "test": "run-s test:node test:web test:format",
     "test:format": "prettier-check '{source,test}/**/*.js'",


### PR DESCRIPTION
Type definitions were not provided for the `web` submodule so I was not able to set the `strict` option of typescript to `true`. I had this error:

```
$ node_modules/.bin/tsc --noEmit
src/main.ts:2:26 - error TS7016: Could not find a declaration file for module 'webdav/web'. '/home/nicolas/Source/js/webdav-drive/node_modules/webdav/web/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/webdav` if it exists or add a new declaration (.d.ts) file containing `declare module 'webdav/web';`

2 import { AuthType } from "webdav/web";
                           ~~~~~~~~~~~~
```

I tested these changes on my project using [npm local paths](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#local-paths) and it works perfectly.

Here is the resulted web directory:

```
$ tree web
web
├── auth
│   ├── basic.d.ts
│   ├── digest.d.ts
│   ├── index.d.ts
│   └── oauth.d.ts
├── compat
│   ├── arrayBuffer.d.ts
│   ├── buffer.d.ts
│   └── patcher.d.ts
├── factory.d.ts
├── index.d.ts
├── index.js
├── operations
│   ├── copyFile.d.ts
│   ├── createDirectory.d.ts
│   ├── createStream.d.ts
│   ├── customRequest.d.ts
│   ├── deleteFile.d.ts
│   ├── directoryContents.d.ts
│   ├── exists.d.ts
│   ├── getFileContents.d.ts
│   ├── getQuota.d.ts
│   ├── moveFile.d.ts
│   ├── putFileContents.d.ts
│   └── stat.d.ts
├── request.d.ts
├── response.d.ts
├── tools
│   ├── crypto.d.ts
│   ├── dav.d.ts
│   ├── encode.d.ts
│   ├── headers.d.ts
│   ├── merge.d.ts
│   ├── path.d.ts
│   ├── quota.d.ts
│   ├── size.d.ts
│   └── url.d.ts
└── types.d.ts
```