### PR TITLE
Consider `status` in `propstat` when doing `stat`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ When making a pull request for an existing issue or feature that is clearly bene
 When making a pull request for an item not listed as an issue or that is controversial (also subject to opinion), be aware that the request may be denied and the PR closed. It is always best to create an issue for a discussion before making a PR, if you are unsure of the feature's worth.
 
 ## Documentation
-PRs to add/update documentation are welcome, but please, ensure that you edit in **Markdown** with as little HTML as possible (none is preferrable). Do not use auto-formatters to generate the documentation files.
+PRs to add/update documentation are welcome, but please, ensure that you edit in **Markdown** with as little HTML as possible (none is preferable). Do not use auto-formatters to generate the documentation files.
 
 `API.md` is generated on release - there is no need to update it yourself.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2581,6 +2581,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "buffer-equals": "^2.0.0",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "concurrently": "^6.0.0",
     "copy-dir": "^1.3.0",
     "directory-exists": "^2.0.1",

--- a/source/types.ts
+++ b/source/types.ts
@@ -33,6 +33,7 @@ export interface DAVResultResponse {
     href: string;
     propstat: {
         prop: DAVResultResponseProps;
+        status: string;
     }
 }
 

--- a/test/index.node.js
+++ b/test/index.node.js
@@ -1,8 +1,12 @@
 const { expect } = require("chai");
+const chai = require("chai");
 const sinon = require("sinon");
+const chaiAsPromised = require("chai-as-promised");
 
 // Assign testing globals
 Object.assign(global, {
     expect,
     sinon
 });
+
+chai.use(chaiAsPromised);

--- a/test/node/operations/stat.spec.js
+++ b/test/node/operations/stat.spec.js
@@ -4,7 +4,9 @@ const {
     SERVER_USERNAME,
     clean,
     createWebDAVClient,
-    createWebDAVServer
+    createWebDAVServer,
+    useCustomXmlResponse,
+    restoreRequests
 } = require("../../helpers.node.js");
 
 describe("stat", function() {
@@ -69,6 +71,31 @@ describe("stat", function() {
             expect(stat).to.have.property("lastmod").that.is.a.string;
             expect(stat).to.have.property("type", "directory");
             expect(stat).to.have.property("size", 0);
+        });
+    });
+
+    it("throws 404 on non-existent file", function() {
+        return expect(this.client.stat("/does-not-exist")).to.eventually.be.rejected.and.have.property("status", 404);
+    });
+
+    describe("when requesting stat from NGinx webdav server", function() {
+        beforeEach(function() {
+            this.client = createWebDAVClient(`http://localhost:${SERVER_PORT}/webdav/server`, {
+                username: SERVER_USERNAME,
+                password: SERVER_PASSWORD
+            });
+            useCustomXmlResponse("nginx-not-found");
+        });
+
+        afterEach(function() {
+            restoreRequests();
+        });
+
+        it("throws 404 on non-existent file", function() {
+            return expect(this.client.stat("/does-not-exist")).to.eventually.be.rejected.and.have.property(
+                "status",
+                404
+            );
         });
     });
 

--- a/test/responses/nginx-not-found.xml
+++ b/test/responses/nginx-not-found.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<D:multistatus xmlns:D="DAV:">
+    <D:response>
+        <D:href>/p-nice/does-not-exist</D:href>
+        <D:propstat>
+            <D:prop>
+            </D:prop>
+            <D:status>HTTP/1.1 404 Not Found</D:status>
+        </D:propstat>
+    </D:response>
+</D:multistatus>


### PR DESCRIPTION
## Why
When `PROPFIND` is sent to Nginx webdav server on a non-existent file, it responds with `207 Multi-Status`, but contains the `404` in the `status` element of `propstat`. This is an example response from Nginx:
```xml
<?xml version="1.0" encoding="utf-8" ?>
<D:multistatus xmlns:D="DAV:">
    <D:response>
        <D:href>/p-nice/does-not-exist</D:href>
        <D:propstat>
            <D:prop></D:prop>
            <D:status>HTTP/1.1 404 Not Found</D:status>
        </D:propstat>
    </D:response>
</D:multistatus>
```

The [RFC 4918, Section 9.1.2.](https://tools.ietf.org/html/rfc4918#section-9.1.2) names the `404` status as valid value for the `status` element in `propstat`, but it does not have an example with this combination (`207` response status and `404` in the `status` element).

## Before
Before this PR, the client would treat the `PROPFIND` responses for non-existent resources from NGinx as if the resources existed. Not considering the `status` element of `propstat` in the response body.

## After
Throw error when doing `stat` on non-existent resource even if the HTTP status of the response is `207`, but the `status` in `propstat` element is `>= 400`.

## Notes
We have been using this code at Deepnote as a package patch for couple months already without any issues, but this was still using the non-TypeScript version of this library. I have waited with creation of the PR before the TypeScript version was out (thank you very much for the TS version, very appreciated).

The same approach could in theory be applied on all `Multi-Status` responses to `PROPFIND` -- I can namely think of the `getDirectoryContents` function.