### PR TITLE
Ensure proper collection path when creating directory

### DIFF
--- a/source/operations/createDirectory.ts
+++ b/source/operations/createDirectory.ts
@@ -12,11 +12,25 @@ export async function createDirectory(
 ): Promise<void> {
     if (options.recursive === true) return createDirectoryRecursively(context, dirPath, options);
     const requestOptions = prepareRequestOptions({
-        url: joinURL(context.remoteURL, encodePath(dirPath)),
+        url: joinURL(context.remoteURL, ensureCollectionPath(encodePath(dirPath))),
         method: "MKCOL"
     }, context, options);
     const response = await request(requestOptions);
     handleResponseCode(context, response);
+}
+
+/**
+ * Ensure the path is a proper "collection" path by ensuring it has a trailing "/".
+ * The proper format of collection according to the specification does contain the trailing slash.
+ * http://www.webdav.org/specs/rfc4918.html#rfc.section.5.2
+ * @param path Path of the collection
+ * @return string Path of the collection with appended trailing "/" in case the `path` does not have it.
+ */
+function ensureCollectionPath(path: string): string {
+    if (!path.endsWith("/")) {
+        return path + "/";
+    }
+    return path;
 }
 
 async function createDirectoryRecursively(

--- a/test/node/operations/createDirectory.spec.js
+++ b/test/node/operations/createDirectory.spec.js
@@ -47,6 +47,12 @@ describe("createDirectory", function() {
             .that.has.property("X-test", "test");
     });
 
+    it("adds the trailing slash to the directory name if missing", async function() {
+        await this.client.createDirectory("/subdirectory-1122");
+        const [requestOptions] = this.requestSpy.firstCall.args;
+        expect(requestOptions.url).to.satisfy(url => url.endsWith("/"));
+    });
+
     describe("with recursive option", function() {
         it("supports creating deep directories", async function() {
             const newDir = path.resolve(__dirname, "../../testContents/a/b/c/d/e");


### PR DESCRIPTION
According to the specification (http://www.webdav.org/specs/rfc4918.html#rfc.section.5.2) the collection URI contains the trailing slash. While the specification allows that some implementations may treat the URI without the trailing slash as if it had it, some implementations (nginx namely) is strict about this and only supports the URIs with the trailing slash.

This ensures the URI has the trailing slash before sending it via `MKCOL`.