### PR TITLE
Add response to the WebDAVClientError type

### DIFF
--- a/source/response.ts
+++ b/source/response.ts
@@ -1,10 +1,9 @@
 import minimatch from "minimatch";
+import { AxiosResponse } from "axios";
 import { FileStat, Response, ResponseDataDetailed, WebDAVClientContext, WebDAVClientError } from "./types";
-import {AxiosResponse} from "axios";
 
 export function handleResponseCode(context: WebDAVClientContext, response: Response): Response {
     const status = response.status;
-
     if (status === 401 && context.digest) return response;
     if (status >= 400) {
         const err: WebDAVClientError = new Error(`Invalid response: ${status} ${response.statusText}`) as WebDAVClientError;

--- a/source/response.ts
+++ b/source/response.ts
@@ -1,5 +1,4 @@
 import minimatch from "minimatch";
-import { AxiosResponse } from "axios";
 import {
     FileStat,
     Response,
@@ -16,7 +15,7 @@ export function handleResponseCode(context: WebDAVClientContext, response: Respo
             `Invalid response: ${status} ${response.statusText}`
         ) as WebDAVClientError;
         err.status = status;
-        err.response = response as AxiosResponse;
+        err.response = response;
         throw err;
     }
     return response;

--- a/source/response.ts
+++ b/source/response.ts
@@ -1,12 +1,15 @@
 import minimatch from "minimatch";
 import { FileStat, Response, ResponseDataDetailed, WebDAVClientContext, WebDAVClientError } from "./types";
+import {AxiosResponse} from "axios";
 
 export function handleResponseCode(context: WebDAVClientContext, response: Response): Response {
     const status = response.status;
+
     if (status === 401 && context.digest) return response;
     if (status >= 400) {
         const err: WebDAVClientError = new Error(`Invalid response: ${status} ${response.statusText}`) as WebDAVClientError;
         err.status = status;
+        err.response = response as AxiosResponse;
         throw err;
     }
     return response;

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,4 +1,5 @@
 import Stream from "stream";
+import {AxiosResponse} from "axios";
 
 export type AuthHeader = string;
 
@@ -231,6 +232,7 @@ export interface WebDAVClientContext {
 
 export interface WebDAVClientError extends Error {
     status?: number;
+    response?: AxiosResponse;
 }
 
 export interface WebDAVClientOptions {

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,5 +1,4 @@
 import Stream from "stream";
-import { AxiosResponse } from "axios";
 
 export type AuthHeader = string;
 
@@ -251,8 +250,8 @@ export interface WebDAVClientContext {
 }
 
 export interface WebDAVClientError extends Error {
-    response?: AxiosResponse;
     status?: number;
+    response?: Response;
 }
 
 export interface WebDAVClientOptions {

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,5 +1,5 @@
 import Stream from "stream";
-import {AxiosResponse} from "axios";
+import { AxiosResponse } from "axios";
 
 export type AuthHeader = string;
 
@@ -231,8 +231,8 @@ export interface WebDAVClientContext {
 }
 
 export interface WebDAVClientError extends Error {
-    status?: number;
     response?: AxiosResponse;
+    status?: number;
 }
 
 export interface WebDAVClientOptions {


### PR DESCRIPTION
Add response property to WebDAVClientError type.

the error handleing is no longer handled by axios (https://github.com/perry-mitchell/webdav-client/blob/master/source/request.ts#L52) so the error object doesn't has access to the HTTP response. this PR fixes that.

