### PR TITLE
fix `normaliseHREF` error when non-string parameters

### DIFF
--- a/source/tools/url.ts
+++ b/source/tools/url.ts
@@ -27,6 +27,6 @@ export function joinURL(...parts: Array<string>): string {
 }
 
 export function normaliseHREF(href: string): string {
-    const normalisedHref = href.replace(/^https?:\/\/[^\/]+/, "");
+    const normalisedHref = String(href).replace(/^https?:\/\/[^\/]+/, "");
     return normalisedHref;
 }


### PR DESCRIPTION
I found this error in some folders

```ts
const data = await client.getDirectoryContents('/xxxx')
```

```ts
 ERROR  href.replace is not a function

  at Object.normaliseHREF (node_modules/webdav/dist/node/tools/url.js:36:31)
  at node_modules/webdav/dist/node/operations/directoryContents.js:91:26
  at Array.map (<anonymous>)
  at getDirectoryFiles (node_modules/webdav/dist/node/operations/directoryContents.js:89:10)
  at Object.<anonymous> (node_modules/webdav/dist/node/operations/directoryContents.js:72:29)
  at step (node_modules/webdav/dist/node/operations/directoryContents.js:33:23)
  at Object.next (node_modules/webdav/dist/node/operations/directoryContents.js:14:53)
  at fulfilled (node_modules/webdav/dist/node/operations/directoryContents.js:5:58)
  at runMicrotasks (<anonymous>)
  at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

I test
```ts
function normaliseHREF(href) {
    try {
      var normalisedHref = href.replace(/^https?:\/\/[^\/]+/, "");
      return normalisedHref;
    }catch(err) {
      throw new Error(`normaliseHREF: href=${href} type=${typeof href}`)
    }
}
```

got
```ts
 ERROR  normaliseHREF: href=NaN type=number

  at Object.normaliseHREF (node_modules/webdav/dist/node/tools/url.js:39:15)
  at node_modules/webdav/dist/node/operations/directoryContents.js:91:26
  at Array.map (<anonymous>)
  at getDirectoryFiles (node_modules/webdav/dist/node/operations/directoryContents.js:89:10)
  at Object.<anonymous> (node_modules/webdav/dist/node/operations/directoryContents.js:72:29)
  at step (node_modules/webdav/dist/node/operations/directoryContents.js:33:23)
  at Object.next (node_modules/webdav/dist/node/operations/directoryContents.js:14:53)
  at fulfilled (node_modules/webdav/dist/node/operations/directoryContents.js:5:58)
  at runMicrotasks (<anonymous>)
  at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

Ok... Although I don’t know why there is `NaN`
But after I cast the type to a string, everything looks normal
```ts
function normaliseHREF(href) {
  var normalisedHref = String(href).replace(/^https?:\/\/[^\/]+/, "");
  return normalisedHref;
}
```