### PR TITLE
add signal for WebDAVMethodOptions

### DIFF
--- a/source/request.ts
+++ b/source/request.ts
@@ -34,6 +34,9 @@ export function prepareRequestOptions(
     if (typeof userOptions.data !== "undefined") {
         finalOptions.data = userOptions.data;
     }
+    if (userOptions.signal) {
+        finalOptions.signal = userOptions.signal;
+    }
     if (context.httpAgent) {
         finalOptions.httpAgent = context.httpAgent;
     }

--- a/source/types.ts
+++ b/source/types.ts
@@ -160,6 +160,7 @@ interface RequestOptionsBase {
     url?: string;
     validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
+    signal?: AbortSignal;
 }
 
 export interface RequestOptionsCustom extends RequestOptionsBase {}
@@ -285,4 +286,5 @@ export interface WebDAVClientOptions {
 export interface WebDAVMethodOptions {
     data?: RequestDataPayload;
     headers?: Headers;
+    signal?: AbortSignal;
 }


### PR DESCRIPTION
signal is a common option, not bound to axios, very useful for aborting download or upload.