### PR TITLE
Correctly calculate byte size of the utf8 strings

### DIFF
--- a/source/tools/size.ts
+++ b/source/tools/size.ts
@@ -9,7 +9,7 @@ export function calculateDataLength(data: string | BufferLike): number {
     } else if (isBuffer(data)) {
         return (<Buffer>data).length;
     } else if (typeof data === "string") {
-        return (<string>data).length;
+        return Buffer.byteLength(<string>data);
     }
     throw new Layerr(
         {

--- a/test/node/tools/size.spec.js
+++ b/test/node/tools/size.spec.js
@@ -1,0 +1,8 @@
+const { calculateDataLength } = require("../../../dist/node/tools/size.js");
+
+describe("calculateDataLength", () => {
+    it("Correctly calculates length for utf-8 string", () => {
+        const utf8String = "řeřicha";
+        expect(calculateDataLength(utf8String)).to.equal(9);
+    });
+});


### PR DESCRIPTION
The original implementation started causing problems when the webdav client was used in combination with axios 0.22 and later, as in 0.22 axios [started considering the `Content-Length` passed in the request](https://github.com/axios/axios/pull/2880/files#diff-586c04c24608b86a074073c5514cc195be5c4c87ddb56da233f6d998ada4159fR89-R91) where it previously ignored it and calculated the length on its own.