### PR TITLE
Allow specifying path for quota query

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ const quota: DiskQuota = await client.getQuota();
 |-------------------|-----------|-----------------------------------------------|
 | `options`         | No        | Configuration options.                        |
 | `options.details` | No        | Return detailed results (headers etc.). Defaults to `false`. |
+| `options.path`    | No        | Path used to make the quota request.          |
 
 _`options` extends [method options](#method-options)._
 

--- a/source/operations/getQuota.ts
+++ b/source/operations/getQuota.ts
@@ -9,9 +9,10 @@ export async function getQuota(
     context: WebDAVClientContext,
     options: GetQuotaOptions = {}
 ): Promise<DiskQuota | null | ResponseDataDetailed<DiskQuota | null>> {
+    const path = options.path || "/";
     const requestOptions = prepareRequestOptions(
         {
-            url: joinURL(context.remoteURL, "/"),
+            url: joinURL(context.remoteURL, path),
             method: "PROPFIND",
             headers: {
                 Accept: "text/plain",

--- a/source/types.ts
+++ b/source/types.ts
@@ -116,6 +116,7 @@ export interface GetFileContentsOptions extends WebDAVMethodOptions {
 
 export interface GetQuotaOptions extends WebDAVMethodOptions {
     details?: boolean;
+    path?: string;
 }
 
 export interface Headers {


### PR DESCRIPTION
As it is an optional parameter, I decided to add it to the `getQuotaOptions`. Also, this way it does not break the API.

I added the test for this new option in a separate commit, maybe there was a better way to write it, but I did not take the time to look further.

Closes #237