### PR TITLE
AxiosAdapter option added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 .DS_Store
 .history
+.idea
 .vscode
 .nyc_output
 test.js

--- a/README.md
+++ b/README.md
@@ -141,18 +141,18 @@ The `createClient` method takes a WebDAV service URL, and a configuration option
 The available configuration options are as follows:
 
 | Option             | Default | Description                                                                                                                               |
-|--------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `adapter`          | _None_ | `adapter` allows custom handling of requests. See [AxiosAdapter](https://github.com/axios/axios/blob/v1.x/lib/adapters/README.md)         |
-| `authType`         | `null` | The authentication type to use. If not provided, defaults to trying to detect based upon whether `username` and `password` were provided. |
-| `headers`          | `{}`   | Additional headers provided to all requests. Headers provided here are overridden by method-specific headers, including `Authorization`.  |
-| `httpAgent`        | _None_ | HTTP agent instance. Available only in Node. See [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent).                    |
-| `httpsAgent`       | _None_ | HTTPS agent instance. Available only in Node. See [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent).               |
-| `maxBodyLength`    | _None_ | Maximum body length allowed for sending, in bytes.                                                                                        |
-| `maxContentLength` | _None_ | Maximum content length allowed for receiving, in bytes.                                                                                   |
-| `password`         | _None_ | Password for authentication.                                                                                                              |
-| `token`            | _None_ | Token object for authentication.                                                                                                          |
-| `username`         | _None_ | Username for authentication.                                                                                                              |
-| `withCredentials`  | _None_ | Credentials inclusion setting for Axios.                                                                                                  |
+|--------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `adapter`          | _None_  | `adapter` allows custom handling of requests. See [AxiosAdapter](https://github.com/axios/axios/blob/v1.x/lib/adapters/README.md)         |
+| `authType`         | `null`  | The authentication type to use. If not provided, defaults to trying to detect based upon whether `username` and `password` were provided. |
+| `headers`          | `{}`    | Additional headers provided to all requests. Headers provided here are overridden by method-specific headers, including `Authorization`.  |
+| `httpAgent`        | _None_  | HTTP agent instance. Available only in Node. See [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent).                    |
+| `httpsAgent`       | _None_  | HTTPS agent instance. Available only in Node. See [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent).               |
+| `maxBodyLength`    | _None_  | Maximum body length allowed for sending, in bytes.                                                                                        |
+| `maxContentLength` | _None_  | Maximum content length allowed for receiving, in bytes.                                                                                   |
+| `password`         | _None_  | Password for authentication.                                                                                                              |
+| `token`            | _None_  | Token object for authentication.                                                                                                          |
+| `username`         | _None_  | Username for authentication.                                                                                                              |
+| `withCredentials`  | _None_  | Credentials inclusion setting for Axios.                                                                                                  |
 
 ### Client methods
 

--- a/README.md
+++ b/README.md
@@ -140,18 +140,19 @@ The `createClient` method takes a WebDAV service URL, and a configuration option
 
 The available configuration options are as follows:
 
-| Option        | Default       | Description                                       |
-|---------------|---------------|---------------------------------------------------|
-| `authType`    | `null`        | The authentication type to use. If not provided, defaults to trying to detect based upon whether `username` and `password` were provided. |
-| `headers`     | `{}`          | Additional headers provided to all requests. Headers provided here are overridden by method-specific headers, including `Authorization`. |
-| `httpAgent`   | _None_        | HTTP agent instance. Available only in Node. See [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent). |
-| `httpsAgent`  | _None_        | HTTPS agent instance. Available only in Node. See [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent). |
-| `maxBodyLength` | _None_      | Maximum body length allowed for sending, in bytes. |
-| `maxContentLength` | _None_   | Maximum content length allowed for receiving, in bytes. |
-| `password`    | _None_        | Password for authentication.                      |
-| `token`       | _None_        | Token object for authentication.                  |
-| `username`    | _None_        | Username for authentication.                      |
-| `withCredentials` | _None_    | Credentials inclusion setting for Axios.          |
+| Option             | Default | Description                                                                                                                               |
+|--------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `adapter`          | _None_ | `adapter` allows custom handling of requests. See [AxiosAdapter](https://github.com/axios/axios/blob/v1.x/lib/adapters/README.md)         |
+| `authType`         | `null` | The authentication type to use. If not provided, defaults to trying to detect based upon whether `username` and `password` were provided. |
+| `headers`          | `{}`   | Additional headers provided to all requests. Headers provided here are overridden by method-specific headers, including `Authorization`.  |
+| `httpAgent`        | _None_ | HTTP agent instance. Available only in Node. See [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent).                    |
+| `httpsAgent`       | _None_ | HTTPS agent instance. Available only in Node. See [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent).               |
+| `maxBodyLength`    | _None_ | Maximum body length allowed for sending, in bytes.                                                                                        |
+| `maxContentLength` | _None_ | Maximum content length allowed for receiving, in bytes.                                                                                   |
+| `password`         | _None_ | Password for authentication.                                                                                                              |
+| `token`            | _None_ | Token object for authentication.                                                                                                          |
+| `username`         | _None_ | Username for authentication.                                                                                                              |
+| `withCredentials`  | _None_ | Credentials inclusion setting for Axios.                                                                                                  |
 
 ### Client methods
 

--- a/source/factory.ts
+++ b/source/factory.ts
@@ -1,6 +1,6 @@
 import Stream from "stream";
 import { extractURLPath } from "./tools/url";
-import { setupAuth } from "./auth/index";
+import { setupAuth } from "./auth";
 import { copyFile } from "./operations/copyFile";
 import { createDirectory } from "./operations/createDirectory";
 import { createReadStream, createWriteStream } from "./operations/createStream";
@@ -39,6 +39,7 @@ const DEFAULT_CONTACT_HREF =
 
 export function createClient(remoteURL: string, options: WebDAVClientOptions = {}): WebDAVClient {
     const {
+        adapter,
         authType: authTypeRaw = null,
         contactHref = DEFAULT_CONTACT_HREF,
         headers = {},
@@ -56,6 +57,7 @@ export function createClient(remoteURL: string, options: WebDAVClientOptions = {
         authType = username || password ? AuthType.Password : AuthType.None;
     }
     const context: WebDAVClientContext = {
+        adapter,
         authType,
         contactHref,
         headers: Object.assign({}, headers),

--- a/source/request.ts
+++ b/source/request.ts
@@ -37,6 +37,9 @@ export function prepareRequestOptions(
     if (userOptions.signal) {
         finalOptions.signal = userOptions.signal;
     }
+    if (context.adapter) {
+        finalOptions.adapter = context.adapter;
+    }
     if (context.httpAgent) {
         finalOptions.httpAgent = context.httpAgent;
     }

--- a/source/types.ts
+++ b/source/types.ts
@@ -255,7 +255,7 @@ export interface WebDAVClient {
 }
 
 export interface WebDAVClientContext {
-    adapter: AxiosAdapter;
+    adapter?: AxiosAdapter;
     authType: AuthType;
     contactHref: string;
     digest?: DigestContext;

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,3 +1,4 @@
+import { AxiosAdapter } from "axios";
 import Stream from "stream";
 
 export type AuthHeader = string;
@@ -155,6 +156,7 @@ export interface PutFileContentsOptions extends WebDAVMethodOptions {
 export type RequestDataPayload = string | Buffer | ArrayBuffer | { [key: string]: any };
 
 interface RequestOptionsBase {
+    adapter?: AxiosAdapter;
     data?: RequestDataPayload;
     headers?: Headers;
     httpAgent?: any;
@@ -253,6 +255,7 @@ export interface WebDAVClient {
 }
 
 export interface WebDAVClientContext {
+    adapter: AxiosAdapter;
     authType: AuthType;
     contactHref: string;
     digest?: DigestContext;
@@ -275,6 +278,7 @@ export interface WebDAVClientError extends Error {
 }
 
 export interface WebDAVClientOptions {
+    adapter?: AxiosAdapter;
     authType?: AuthType;
     contactHref?: string;
     headers?: Headers;


### PR DESCRIPTION
Use case:

I'm creating a WebDAV GUI client based on electron with an enabled `nodeIntegration` flag. It means I can use both requests ("browser" and "NodeJS" based).

I wasted a lot of time understanding why `webdav-client` works incorrectly with streams (`fs.createReadStream()`) and when I tried to send file using axios with `agent: require('axios/lib/adapters/http')` option everything started works fine.

So this PR adding `adapter` option support out of the box