### PR TITLE
export createServer

### DIFF
--- a/test/server/index.js
+++ b/test/server/index.js
@@ -57,5 +57,6 @@ function createWebDAVServer(authType) {
 }
 
 module.exports = {
+    createServer,
     createWebDAVServer
 };


### PR DESCRIPTION
let the users to use in unit tests this server source code direct from node_modules - the only possibility to set dir is to copy the server source code.. `path.resolve(__dirname, "../testContents")` -> points to node_modules/../testContents