### PR TITLE
feat: add ts overload to getFileContents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 end_of_line = lf
 insert_final_newline = true
 
-[*.{js,json}]
+[*.{js,json,ts}]
 indent_style = space
 indent_size = 4
 

--- a/source/operations/getFileContents.ts
+++ b/source/operations/getFileContents.ts
@@ -15,6 +15,30 @@ import {
 
 const TRANSFORM_RETAIN_FORMAT = (v: any) => v;
 
+type GetFileContentsBasicOptions = Omit<GetFileContentsOptions, "format" | "details">;
+
+export async function getFileContents(
+    context: WebDAVClientContext,
+    filePath: string,
+    options?: GetFileContentsBasicOptions & { format?: "binary"; details?: false }
+): Promise<BufferLike>;
+export async function getFileContents(
+    context: WebDAVClientContext,
+    filePath: string,
+    options: GetFileContentsBasicOptions & { format: "text"; details?: false }
+): Promise<string>;
+// details
+export async function getFileContents(
+    context: WebDAVClientContext,
+    filePath: string,
+    options: GetFileContentsBasicOptions & { format?: "binary"; details: true }
+): Promise<ResponseDataDetailed<BufferLike>>;
+export async function getFileContents(
+    context: WebDAVClientContext,
+    filePath: string,
+    options: GetFileContentsBasicOptions & { format: "text"; details: true }
+): Promise<ResponseDataDetailed<string>>;
+
 export async function getFileContents(
     context: WebDAVClientContext,
     filePath: string,


### PR DESCRIPTION
so that we get explicit return type when different options provided

```ts
getFileContents({} as any, "/").then(res => res.byteLength); // res: BufferLike

getFileContents({} as any, "/", { format: "text" }).then(res => res.length); // res: string

getFileContents({} as any, "/", { details: true }).then(res => res.data.byteLength); // res: Detail<BufferLike>

getFileContents({} as any, "/", { details: true, format: "text" }).then(res => res.data.length); // res: Detail<string>
```
