### PR TITLE
Added type declaration file for hot-patcher package

### DIFF
--- a/source/declarations/index.d.ts
+++ b/source/declarations/index.d.ts
@@ -1,0 +1,6 @@
+declare module "hot-patcher" {
+    class HotPatcher {
+        patchInline(key: string, method: any, ...args: any[]): any;
+    }
+    export default HotPatcher;
+}


### PR DESCRIPTION
It is added a type declaration file in the used functions of the "hot-pacher" package so that errors are not generated when the ts files are compiled with strict mode active