### PR TITLE
Handle URL encoded paths returned in directory listings

### DIFF
--- a/source/operations/directoryContents.ts
+++ b/source/operations/directoryContents.ts
@@ -55,8 +55,6 @@ function getDirectoryFiles(
         responseItems
             // Map all items to a consistent output structure (results)
             .map(item => {
-                // HREF is the file path (in full)
-                const href = normaliseHREF(item.href);
                 // HREF is the file path (in full).
                 // decodeURIComponent caters for paths that are returned encoded
                 const href = decodeURIComponent(normaliseHREF(item.href));

--- a/source/operations/directoryContents.ts
+++ b/source/operations/directoryContents.ts
@@ -57,6 +57,10 @@ function getDirectoryFiles(
             .map(item => {
                 // HREF is the file path (in full)
                 const href = normaliseHREF(item.href);
+                // HREF is the file path (in full).
+                // decodeURIComponent caters for paths that are returned encoded
+                const href = decodeURIComponent(normaliseHREF(item.href));
+
                 // Each item should contain a stat object
                 const {
                     propstat: { prop: props }


### PR DESCRIPTION
I'm using the Synology (Apache based) WebDAV server and it returns characters like `[` and `]` URL encoded:

Path: `/home/[Reference]/dn-test/test/`
WebDAV response: `<D:href>/home/%5bReference%5d/dn-test/test/</D:href>`

This causes the `pathPosix.relative` call to think it's in a different dir, and the paths all come out prepended with `/../../`. Decoding the href value before using it means it comes out correctly (same as others without those characters). Not sure whether this technically belongs in `normaliseHREF` though.

In the meantime I have a polyfill which tackles it at the `normaliseHREF` side:
```
import * as wurl from "webdav/dist/node/tools/url";
var old = wurl.normaliseHREF;
(wurl as any).normaliseHREF = (href: string) => {
    return decodeURIComponent(old(href));
};
```