### PR TITLE
fix: Fix missing leading slash causing extra getDirectoryContents entries

### DIFF
--- a/source/operations/directoryContents.ts
+++ b/source/operations/directoryContents.ts
@@ -33,7 +33,8 @@ export async function getDirectoryContents(
     const response = await request(requestOptions);
     handleResponseCode(context, response);
     const davResp = await parseXML(response.data as string);
-    let files = getDirectoryFiles(davResp, context.remotePath, remotePath, options.details);
+    const _remotePath = remotePath.startsWith("/") ? remotePath : "/" + remotePath;
+    let files = getDirectoryFiles(davResp, context.remotePath, _remotePath, options.details);
     if (options.glob) {
         files = processGlobFilter(files, options.glob);
     }

--- a/test/node/operations/getDirectoryContents.spec.js
+++ b/test/node/operations/getDirectoryContents.spec.js
@@ -85,6 +85,16 @@ describe("getDirectoryContents", function () {
         });
     });
 
+    it("returns correct results when calling without root slash", function () {
+        return this.client.getDirectoryContents("sub1").then(function (contents) {
+            expect(contents).to.have.lengthOf(2);
+            const sub1 = contents.find(item => item.basename === "irrelephant.jpg");
+            expect(sub1).to.be.ok;
+            const sub2 = contents.find(item => item.basename === "ยากจน #1.txt");
+            expect(sub2).to.be.ok;
+        });
+    });
+
     it("returns correct file results for files with special characters", function () {
         return this.client.getDirectoryContents("/sub1").then(function (contents) {
             const sub1 = contents.find(function (item) {


### PR DESCRIPTION
If you don't have a leading slash passed to `getDirectoryContents`, it will cause it to not properly filter out the current directory from the response. This PR fixes that.

This is the actual cause of the issue I was having in the `webdav-fs` repo. https://github.com/perry-mitchell/webdav-fs/issues/84