### PR TITLE
Preserve stringified numbers with leading zeros

### DIFF
--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -76,7 +76,8 @@ export function parseXML(xml: string): Promise<DAVResult> {
     return new Promise(resolve => {
         const result = xmlParser.parse(xml, {
             arrayMode: false,
-            ignoreNameSpace: true
+            ignoreNameSpace: true,
+            parseTrueNumberOnly: true
             // // We don't use the processors here as decoding is done manually
             // // later on - decoding early would break some path checks.
             // attrValueProcessor: val => decodeHTMLEntities(decodeURIComponent(val)),


### PR DESCRIPTION
Enable the `parseTrueNumberOnly` option from `fast-xml-parser`, see [docs](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/v3/docs.md), to preserve the leading zeros of numbers

### Before
`"00123"` is parsed to `123`

### After
`"00123"` is parsed to `"00123"`