### PR TITLE
fix(exports): allow to import dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
       "browser": "./dist/web/index.js",
       "default": "./dist/node/index.js"
     },
-    "./web": "./dist/web/index.js"
+    "./web": "./dist/web/index.js",
+    "./dist/": "./dist/"
   },
   "type": "module",
   "types": "./dist/node/index.d.ts",


### PR DESCRIPTION
Fix https://github.com/perry-mitchell/webdav-client/issues/339

## Reproducing
```ts
import { request } from 'webdav/dist/node/request.js'
```

## Before
```
ERROR in ./apps/files/src/services/WebdavClient.ts 5:0-54
Module not found: Error: Package path ./dist/node/request.js is not exported from package /home/admin/Docker/server/node_modules/webdav (see exports field in /home/admin/Docker/server/node_modules/webdav/package.json)
Did you miss the leading dot in 'resolve.extensions'? Did you mean '[".*",".ts",".js",".vue"]' instead of '["*",".ts",".js",".vue"]'?
 @ ./apps/files/src/services/Favorites.ts 24:0-53 27:15-24 37:38-46 43:10-18
 @ ./apps/files/src/views/favorites.ts 5:0-52 24:4-15 41:4-15
 @ ./apps/files/src/main.ts 18:0-54 70:0-21
```

## After
Success! :+1: 