### PR TITLE
fix: Do not require esModuleInterop in consuming TypeScript projects

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -1,4 +1,4 @@
-import Stream from "node:stream";
+import * as Stream from "node:stream";
 import { Response } from "@buttercup/fetch";
 
 export { Request, Response } from "@buttercup/fetch";


### PR DESCRIPTION
`node:stream` type is defined like this:

```
declare module 'node:stream' {
    import stream = require('stream');
    export = stream;
}
```

The "correct" way to import from this module in TypeScript is `import * as Stream from ' node:stream'`. Using the default import `import Stream from 'node:stream'` works only when `esModuleInterop`  is enabled, which should not be required of consuming projects.


This fixes this error when using the library without `esModuleInterop` enabled:
``` 
TS1259: Module '"node:stream"' can only be default-imported using the 'esModuleInterop' flag

3 import Stream from "node:stream";
         ~~~~~~

  node_modules/@types/node/stream.d.ts:1338:5
    1338     export = stream;
             ~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag
```