### PR TITLE
fix: Adjusts test script to run node with ts-node as esm loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:node:watch": "nodemon --exec 'npm run test:node' --ignore 'dist/'",
     "test:web": "concurrently --success 'first' --kill-others 'npm run test:web:karma' 'npm run test:web:server'",
     "test:web:karma": "karma start test/karma.conf.cjs",
-    "test:web:server": "ts-node-esm ./test/server.web.ts"
+    "test:web:server": "node --loader ts-node/esm ./test/server.web.ts"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Without this change the tests do not run for me, `npm run test` results in:

```
> webdav@5.2.3 test:web
> concurrently --success 'first' --kill-others 'npm run test:web:karma' 'npm run test:web:server'

[0] 
[0] > webdav@5.2.3 test:web:karma
[0] > karma start test/karma.conf.cjs
[0] 
[1] 
[1] > webdav@5.2.3 test:web:server
[1] > ts-node-esm ./test/server.web.ts
[1] 
[0] Webpack bundling...
[1] TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /home/foo/webdav-client/test/server.web.ts
[1]     at new NodeError (node:internal/errors:405:5)
[1]     at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:99:9)
[1]     at defaultGetFormat (node:internal/modules/esm/get_format:142:36)
[1]     at defaultLoad (node:internal/modules/esm/load:86:20)
[1]     at nextLoad (node:internal/modules/esm/hooks:726:28)
[1]     at load (/home/foo/webdav-client/node_modules/ts-node/dist/child/child-loader.js:19:122)
[1]     at nextLoad (node:internal/modules/esm/hooks:726:28)
[1]     at Hooks.load (node:internal/modules/esm/hooks:370:26)
[1]     at MessagePort.handleMessage (node:internal/modules/esm/worker:168:24)
[1]     at [nodejs.internal.kHybridDispatch] (node:internal/event_target:762:20) {
[1]   code: 'ERR_UNKNOWN_FILE_EXTENSION'
[1] }
[1] npm run test:web:server exited with code 1
--> Sending SIGTERM to other processes..
[0] (node:11661) [DEP_WEBPACK_COMPILATION_NORMAL_MODULE_LOADER_HOOK] DeprecationWarning: Compilation.hooks.normalModuleLoader was moved to NormalModule.getCompilationHooks(compilation).loader
[0] (Use `node20 --trace-deprecation ...` to show where the warning was created)
```

(Using current LTS Node 20)