### PR TITLE
feat: Implement `SEARCH` according to `rfc5323`

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,34 @@ await client.putFileContents("/my/file.txt", str);
 
 _`options` extends [method options](#method-options)._
 
+#### search
+
+Perform a WebDAV search as per [rfc5323](https://www.ietf.org/rfc/rfc5323.html).
+
+```typescript
+const searchRequest = `
+<?xml version="1.0" encoding="UTF-8"?>
+<d:searchrequest xmlns:d="DAV:" xmlns:f="http://example.com/foo">
+    <f:natural-language-query>
+    Find files changed last week
+    </f:natural-language-query>
+</d:searchrequest>
+`
+const result: SearchResult = await client.search("/some-collection", { data: searchRequest });
+```
+
+```typescript
+(path: string, options?: SearchOptions) => Promise<SearchResult | ResponseDataDetailed<SearchResult>>
+```
+
+| Argument          | Required  | Description                                   |
+|-------------------|-----------|-----------------------------------------------|
+| `path`            | Yes       | Remote path to which executes the search.     |
+| `options`         | No        | Configuration options.                        |
+| `options.details` | No        | Return detailed results (headers etc.). Defaults to `false`. |
+
+_`options` extends [method options](#method-options)._
+
 #### stat
 
 Get a file or directory stat object. Returns an [item stat](#item-stats).
@@ -655,7 +683,7 @@ Properties:
 
 #### Detailed responses
 
-Requests that return results, such as `getDirectoryContents`, `getFileContents`, `getQuota` and `stat`, can be configured to return more detailed information, such as response headers. Pass `{ details: true }` to their options argument to receive an object like the following:
+Requests that return results, such as `getDirectoryContents`, `getFileContents`, `getQuota`, `search` and `stat`, can be configured to return more detailed information, such as response headers. Pass `{ details: true }` to their options argument to receive an object like the following:
 
 | Property     | Type            | Description                            |
 |--------------|-----------------|----------------------------------------|

--- a/source/factory.ts
+++ b/source/factory.ts
@@ -12,6 +12,7 @@ import { getFileContents, getFileDownloadLink } from "./operations/getFileConten
 import { lock, unlock } from "./operations/lock.js";
 import { getQuota } from "./operations/getQuota.js";
 import { getStat } from "./operations/stat.js";
+import { getSearch } from "./operations/search.js";
 import { moveFile } from "./operations/moveFile.js";
 import { getFileUploadLink, putFileContents } from "./operations/putFileContents.js";
 import {
@@ -27,6 +28,7 @@ import {
     LockOptions,
     PutFileContentsOptions,
     RequestOptionsCustom,
+    SearchOptions,
     StatOptions,
     WebDAVClient,
     WebDAVClientContext,
@@ -104,6 +106,7 @@ export function createClient(remoteURL: string, options: WebDAVClientOptions = {
             data: string | BufferLike | Stream.Readable,
             options?: PutFileContentsOptions
         ) => putFileContents(context, filename, data, options),
+        search: (path: string, options?: SearchOptions) => getSearch(context, path, options),
         setHeaders: (headers: Headers) => {
             context.headers = Object.assign({}, headers);
         },

--- a/source/operations/search.ts
+++ b/source/operations/search.ts
@@ -1,0 +1,38 @@
+import { parseSearch, parseXML } from "../tools/dav.js";
+import { joinURL } from "../tools/url.js";
+import { encodePath } from "../tools/path.js";
+import { request, prepareRequestOptions } from "../request.js";
+import { handleResponseCode, processResponsePayload } from "../response.js";
+import {
+    SearchResult,
+    ResponseDataDetailed,
+    SearchOptions,
+    WebDAVClientContext
+} from "../types.js";
+
+export async function getSearch(
+    context: WebDAVClientContext,
+    searchArbiter: string,
+    options: SearchOptions = {}
+): Promise<SearchResult | ResponseDataDetailed<SearchResult>> {
+    const { details: isDetailed = false } = options;
+    const requestOptions = prepareRequestOptions(
+        {
+            url: joinURL(context.remoteURL, encodePath(searchArbiter)),
+            method: "SEARCH",
+            headers: {
+                Accept: "text/plain,application/xml",
+                // Ensure a Content-Type header is set was this is required by e.g. sabre/dav
+                "Content-Type": context.headers["Content-Type"] || "application/xml; charset=utf-8"
+            }
+        },
+        context,
+        options
+    );
+    const response = await request(requestOptions);
+    handleResponseCode(context, response);
+    const responseText = await response.text();
+    const responseData = await parseXML(responseText);
+    const results = parseSearch(responseData, searchArbiter, isDetailed);
+    return processResponsePayload(response, results, isDetailed);
+}

--- a/test/node/operations/search.spec.ts
+++ b/test/node/operations/search.spec.ts
@@ -1,0 +1,95 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { expect } from "chai";
+import {
+    SERVER_PASSWORD,
+    SERVER_PORT,
+    SERVER_USERNAME,
+    clean,
+    createWebDAVClient,
+    createWebDAVServer,
+    restoreRequests,
+    returnFakeResponse,
+    useRequestSpy
+} from "../../helpers.node.js";
+import { ResponseDataDetailed, SearchResult, WebDAVClient } from "../../../source/types.js";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function useTruncatedSearchResults() {
+    returnFakeResponse(
+        fs.readFileSync(path.resolve(dirname, "../../responses/search-truncated.xml"), "utf8")
+    );
+}
+
+function useFullSearchResults() {
+    returnFakeResponse(
+        fs.readFileSync(path.resolve(dirname, "../../responses/search-full-success.xml"), "utf8")
+    );
+}
+
+const searchRequest = `<?xml version="1.0" encoding="UTF-8"?>
+<d:searchrequest xmlns:d="DAV:" xmlns:f="http://example.com/foo">
+    <f:natural-language-query>
+    Find files changed 2023-08-03
+    </f:natural-language-query>
+</d:searchrequest>
+`;
+
+describe("search", function () {
+    let client: WebDAVClient;
+    beforeEach(function () {
+        // fake client, not actually used when mocking responses
+        client = createWebDAVClient(`http://localhost:${SERVER_PORT}/webdav/server`, {
+            username: SERVER_USERNAME,
+            password: SERVER_PASSWORD
+        });
+        clean();
+        this.server = createWebDAVServer();
+        this.requestSpy = useRequestSpy();
+        return this.server.start();
+    });
+
+    afterEach(function () {
+        restoreRequests();
+        return this.server.stop();
+    });
+
+    it("returns full search response", function () {
+        useFullSearchResults();
+        return client.search("/", { data: searchRequest }).then(function (result) {
+            expect(result).to.be.an("object");
+            expect(result).to.have.property("truncated", false);
+            expect(result).to.have.property("results");
+            expect((result as SearchResult).results.length).to.equal(2);
+            expect((result as SearchResult).results[0].basename).to.equal("first-file.md");
+            expect((result as SearchResult).results[1].basename).to.equal("second file.txt");
+        });
+    });
+
+    it("returns full detailed search response", function () {
+        useFullSearchResults();
+        return client.search("/", { data: searchRequest, details: true }).then(function (result) {
+            expect(result).to.be.an("object");
+            result = (result as ResponseDataDetailed<SearchResult>).data;
+            expect(result).to.be.an("object");
+            expect(result).to.have.property("truncated", false);
+            expect(result).to.have.property("results");
+            expect(result.results.length).to.equal(2);
+            expect(result.results[0].basename).to.equal("first-file.md");
+            expect(result.results[0].props.getcontenttype).to.equal("text/markdown");
+        });
+    });
+
+    it("returns truncated search response", function () {
+        useTruncatedSearchResults();
+        return client.search("/", { data: searchRequest }).then(function (result) {
+            expect(result).to.be.an("object");
+            expect(result).to.have.property("truncated", true);
+            expect(result).to.have.property("results");
+            expect((result as SearchResult).results.length).to.equal(1);
+            expect((result as SearchResult).results[0].basename).to.equal("first-file.md");
+        });
+    });
+});

--- a/test/responses/search-full-success.xml
+++ b/test/responses/search-full-success.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<d:multistatus
+	xmlns:d="DAV:">
+	<d:response>
+		<d:href>/first-file.md</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength>0</d:getcontentlength>
+				<d:getcontenttype>text/markdown</d:getcontenttype>
+				<d:getetag>&quot;54d5b8eac2d78c7824925f2fa008bc8d&quot;</d:getetag>
+				<d:getlastmodified>Thu, 03 Aug 2023 21:19:11 GMT</d:getlastmodified>
+				<d:resourcetype/>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/second%20file.txt</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength>164</d:getcontentlength>
+				<d:getcontenttype>text/plain</d:getcontenttype>
+				<d:getetag>&quot;a604cf383444aab743c71f12b81de338&quot;</d:getetag>
+				<d:getlastmodified>Thu, 03 Aug 2023 16:12:57 GMT</d:getlastmodified>
+				<d:resourcetype/>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+	</d:response>
+</d:multistatus>

--- a/test/responses/search-truncated.xml
+++ b/test/responses/search-truncated.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<d:multistatus
+	xmlns:d="DAV:">
+	<d:response>
+		<d:href>/first-file.md</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength>0</d:getcontentlength>
+				<d:getcontenttype>text/markdown</d:getcontenttype>
+				<d:getetag>&quot;54d5b8eac2d78c7824925f2fa008bc8d&quot;</d:getetag>
+				<d:getlastmodified>Thu, 03 Aug 2023 21:19:11 GMT</d:getlastmodified>
+				<d:resourcetype/>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:quota-available-bytes/>
+				<nc:is-encrypted/>
+				<oc:owner-display-name/>
+				<oc:owner-id/>
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/</d:href>
+		<d:status>HTTP/1.1 507 Insufficient Storage</d:status>
+	</d:response>
+</d:multistatus>


### PR DESCRIPTION
* Fixes #205 

This implements the WebDAV search request.
One real life example would be if you want to query recently changed files from Nextcloud, then this can be used like this:

```js
const query = `<?xml version="1.0" encoding="UTF-8"?>
<d:searchrequest xmlns:d="DAV:" xmlns:ns="https://github.com/icewind1991/SearchDAV/ns">
	<d:basicsearch>
		<d:select>
			<d:prop>
			<d:getcontentlength />
			<d:getcontenttype />
			<d:getetag />
			<d:getlastmodified />
			</d:prop>
		</d:select>
		<d:from>
			<d:scope>
				<d:href>/files/YOUR_USER_ID/</d:href>
				<d:depth>infinity</d:depth>
			</d:scope>
		</d:from>
		<d:where>
			<d:gt>
				<d:prop>
					<d:getlastmodified/>
				</d:prop>
				<d:literal>${Math.round(Date.now() / 1000 - 24 * 60 * 60)}</d:literal>
			</d:gt>
		</d:where>
		<d:limit>
			<d:nresults>100</d:nresults>
			<ns:firstresult>0</ns:firstresult>
		</d:limit>
	</d:basicsearch>
</d:searchrequest>`;

// client with base path `SERVER/remote.php/dav`
client.search('/', { data: query })
```