### PR TITLE
fix: The `exports` field should use wildcard exports instead of folder mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "default": "./dist/node/index.js"
     },
     "./web": "./dist/web/index.js",
-    "./dist/": "./dist/"
+    "./dist/*": "./dist/*"
   },
   "react-native": "./dist/web/index.js",
   "type": "module",


### PR DESCRIPTION
* Resolved #355 