### PR TITLE
chore(deps): update fast-xml-parser to 4.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^0.27.2",
         "base-64": "^1.0.0",
         "byte-length": "^1.0.2",
-        "fast-xml-parser": "^3.19.0",
+        "fast-xml-parser": "^4.2.4",
         "he": "^1.2.0",
         "hot-patcher": "^1.0.0",
         "layerr": "^0.1.2",
@@ -3900,18 +3900,24 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
-      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
-        "strnum": "^1.0.4"
+        "strnum": "^1.0.5"
       },
       "bin": {
-        "xml2js": "cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastest-levenshtein": {
@@ -11785,11 +11791,11 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
-      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
       "requires": {
-        "strnum": "^1.0.4"
+        "strnum": "^1.0.5"
       }
     },
     "fastest-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "axios": "^0.27.2",
     "base-64": "^1.0.0",
     "byte-length": "^1.0.2",
-    "fast-xml-parser": "^3.19.0",
+    "fast-xml-parser": "^4.2.4",
     "he": "^1.2.0",
     "hot-patcher": "^1.0.0",
     "layerr": "^0.1.2",

--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -1,5 +1,5 @@
 import path from "path-posix";
-import xmlParser from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import nestedProp from "nested-property";
 import { decodeHTMLEntities } from "./encode";
 import { normalisePath } from "./path";
@@ -72,16 +72,23 @@ function normaliseResult(result: DAVResultRaw): DAVResult {
     return output as DAVResult;
 }
 
+function getParser(): XMLParser {
+    return new XMLParser({
+        removeNSPrefix: true,
+        numberParseOptions: {
+            hex: true,
+            leadingZeros: false
+        }
+        // // We don't use the processors here as decoding is done manually
+        // // later on - decoding early would break some path checks.
+        // attributeValueProcessor: val => decodeHTMLEntities(decodeURIComponent(val)),
+        // tagValueProcessor: val => decodeHTMLEntities(decodeURIComponent(val))
+    });
+}
+
 export function parseXML(xml: string): Promise<DAVResult> {
     return new Promise(resolve => {
-        const result = xmlParser.parse(xml, {
-            arrayMode: false,
-            ignoreNameSpace: true
-            // // We don't use the processors here as decoding is done manually
-            // // later on - decoding early would break some path checks.
-            // attrValueProcessor: val => decodeHTMLEntities(decodeURIComponent(val)),
-            // tagValueProcessor: val => decodeHTMLEntities(decodeURIComponent(val))
-        });
+        const result = getParser().parse(xml);
         resolve(normaliseResult(result));
     });
 }

--- a/source/tools/xml.ts
+++ b/source/tools/xml.ts
@@ -1,9 +1,9 @@
-import xmlParser, { j2xParser as XMLParser } from "fast-xml-parser";
+import { XMLParser, XMLBuilder } from "fast-xml-parser";
 
 type NamespaceObject = { [key: string]: any };
 
 export function generateLockXML(ownerHREF: string): string {
-    return getParser().parse(
+    return getBuilder().build(
         namespace(
             {
                 lockinfo: {
@@ -24,12 +24,20 @@ export function generateLockXML(ownerHREF: string): string {
     );
 }
 
-function getParser(): XMLParser {
-    return new XMLParser({
+function getBuilder(): XMLBuilder {
+    return new XMLBuilder({
         attributeNamePrefix: "@_",
         format: true,
         ignoreAttributes: false,
-        supressEmptyNode: true
+        suppressEmptyNode: true
+    });
+}
+
+function getParser(): XMLParser {
+    return new XMLParser({
+        removeNSPrefix: true,
+        parseAttributeValue: true,
+        parseTagValue: true
     });
 }
 
@@ -51,10 +59,5 @@ function namespace<T extends NamespaceObject>(obj: T, ns: string): T {
 }
 
 export function parseGenericResponse(xml: string): Object {
-    return xmlParser.parse(xml, {
-        arrayMode: false,
-        ignoreNameSpace: true,
-        parseAttributeValue: true,
-        parseNodeValue: true
-    });
+    return getParser().parse(xml);
 }


### PR DESCRIPTION
Backport of https://github.com/perry-mitchell/webdav-client/pull/344, to v4 to unblock folks who can't easily upgrade to the 5.x versions of webdav that require an ES modules based setup. There are no differences between the PRs

--- 
Resolves #336 