### PR TITLE
fix: Relative filename

### DIFF
--- a/source/operations/directoryContents.ts
+++ b/source/operations/directoryContents.ts
@@ -76,7 +76,9 @@ function getDirectoryFiles(
         const filename =
             serverBase === "/"
                 ? decodeURIComponent(normalisePath(href))
-                : decodeURIComponent(normalisePath(pathPosix.relative(serverBase, href)));
+                : normalisePath(
+                      pathPosix.relative(decodeURIComponent(serverBase), decodeURIComponent(href))
+                  );
         return prepareFileFromProps(props, filename, isDetailed);
     });
 


### PR DESCRIPTION
Fix incorrect filename due to the XML encoded href property being compared to a possibly non-encoded base url

### Before
```jsonc
"filename": "/../aA0 _.@-'"
```

### After
```jsonc
"filename": "/"
```