### PR TITLE
fix: Do not double decode XML entities in filenames

### DIFF
--- a/source/operations/directoryContents.ts
+++ b/source/operations/directoryContents.ts
@@ -66,7 +66,7 @@ function getDirectoryFiles(
 
     // Map all items to a consistent output structure (results)
     const nodes = responseItems.map(item => {
-        // HREF is the file path (in full)
+        // HREF is the file path (in full) - The href is already XML entities decoded (e.g. foo&amp;bar is reverted to foo&bar)
         const href = normaliseHREF(item.href);
         // Each item should contain a stat object
         const {

--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -112,7 +112,7 @@ export function parseXML(xml: string): Promise<DAVResult> {
 
 export function prepareFileFromProps(
     props: DAVResultResponseProps,
-    rawFilename: string,
+    filename: string,
     isDetailed: boolean = false
 ): FileStat {
     // Last modified time, raw size, item type and mime
@@ -129,7 +129,6 @@ export function prepareFileFromProps(
         typeof resourceType.collection !== "undefined"
             ? "directory"
             : "file";
-    const filename = decodeHTMLEntities(rawFilename);
     const stat: FileStat = {
         filename,
         basename: path.basename(filename),

--- a/test/responses/propfind-href-html-entities.xml
+++ b/test/responses/propfind-href-html-entities.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+	<d:response>
+		<d:href>http://example.com/files/%26amp%3b.md</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength>0</d:getcontentlength>
+				<d:getcontenttype>text/markdown</d:getcontenttype>
+				<d:getetag>&quot;e9fb0c7d776a0607e2277aad4cc74a08&quot;</d:getetag>
+				<d:getlastmodified>Sun, 04 Feb 2024 14:09:50 GMT</d:getlastmodified>
+				<d:resourcetype/>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:quota-available-bytes/>
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+</d:multistatus>

--- a/test/responses/propfind-href-with-query.xml
+++ b/test/responses/propfind-href-with-query.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+	<d:response>
+		<d:href>/files/some%20file?foo=1&amp;bar=2</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength>0</d:getcontentlength>
+				<d:getcontenttype>text/markdown</d:getcontenttype>
+				<d:getetag>&quot;e9fb0c7d776a0607e2277aad4cc74a08&quot;</d:getetag>
+				<d:getlastmodified>Sun, 04 Feb 2024 14:09:50 GMT</d:getlastmodified>
+				<d:resourcetype/>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+	</d:response>
+</d:multistatus>


### PR DESCRIPTION
* Resolves #363 

The `href` property is already decoded by `parseXML` meaning all XML entities like `&amp;` were decoded. The href just needs to be url decoded.

This prevents issues were files like `a &amp; b.txt` were returned with the wrong name `a & b.txt`

Ref: https://datatracker.ietf.org/doc/html/rfc4918#section-8.3