### PR TITLE
Update customRequest section in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,10 +326,9 @@ const resp: Response = await this.client.customRequest("/alrighty.jpg", {
     headers: {
         Accept: "text/plain",
         Depth: "0"
-    },
-    responseType: "text"
+    }
 });
-const result: DAVResult = await parseXML(resp.data);
+const result: DAVResult = await parseXML(await resp.text());
 const stat: FileStat = parseStat(result, "/alrighty.jpg", false);
 ```
 


### PR DESCRIPTION
Reflect changes to the underlying request library. Since axios is not longer used, `responseType` and `response.data` can no longer be used.