### PR TITLE
fix: also export types for node next module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     ".": {
       "browser": "./dist/web/index.js",
       "react-native": "./dist/react-native/index.js",
+      "types": "./dist/node/index.d.ts",
       "default": "./dist/node/index.js"
     },
     "./react-native": "./dist/react-native/index.js",


### PR DESCRIPTION
When using node next / node16 module resolution (`exports` field), then Typescript will no longer check `types` field in package json but use `types` from the `exports` field that is currently being used.