### PR TITLE
fix(types): correct types for quota bytes

### DIFF
--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -237,7 +237,7 @@ export function parseSearch(result: DAVResult, searchArbiter: string, isDetailed
  * @returns The value in bytes, or another indicator
  */
 export function translateDiskSpace(value: string | number): DiskQuotaAvailable {
-    switch (value.toString()) {
+    switch (String(value)) {
         case "-3":
             return "unlimited";
         case "-2":
@@ -246,6 +246,6 @@ export function translateDiskSpace(value: string | number): DiskQuotaAvailable {
             // -1 is non-computed
             return "unknown";
         default:
-            return parseInt(value as string, 10);
+            return parseInt(String(value), 10);
     }
 }

--- a/source/tools/quota.ts
+++ b/source/tools/quota.ts
@@ -11,7 +11,8 @@ export function parseQuota(result: DAVResult): DiskQuota | null {
         } = responseItem;
         return typeof quotaUsed !== "undefined" && typeof quotaAvail !== "undefined"
             ? {
-                  used: parseInt(quotaUsed, 10),
+                  // As it could be both a string or a number ensure we are working with a number
+                  used: parseInt(String(quotaUsed), 10),
                   available: translateDiskSpace(quotaAvail)
               }
             : null;

--- a/source/types.ts
+++ b/source/types.ts
@@ -70,8 +70,8 @@ export interface DAVResultResponseProps {
     getetag?: string;
     getcontentlength?: string;
     getcontenttype?: string;
-    "quota-available-bytes"?: any;
-    "quota-used-bytes"?: string;
+    "quota-available-bytes"?: string | number;
+    "quota-used-bytes"?: string | number;
 
     [additionalProp: string]: unknown;
 }


### PR DESCRIPTION
As per RFC the value shall be octets representing the quota, in all cases I know the value will be parsed to `number` by the XML parser. (tested e.g. with Sabre / Nextcloud).

While `any` allowed everything, the type `string` for *quota-used-bytes* was wrong as mostly a number is returned (but there might be rare cases of string, like "unlimited" (even if the RFC does not mention this), so lets keep the `string` type in addition.