### PR TITLE
fix(types): `resourcetype` can have any type, so can `collection`

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -64,7 +64,7 @@ export type DAVResultResponse = DAVResultBaseResponse &
 export interface DAVResultResponseProps {
     displayname: string;
     resourcetype: {
-        collection?: boolean;
+        collection?: unknown;
     };
     getlastmodified?: string;
     getetag?: string;


### PR DESCRIPTION
For e.g. SabreDAV collection is only set, meaning its type after parsing by the XML parser will be `string` and its value will be just the empty string.