### PR TITLE
fix(dav): The `displayname` prop should always be a string

### DIFF
--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -146,6 +146,10 @@ export function prepareFileFromProps(
         stat.mime = mimeType && typeof mimeType === "string" ? mimeType.split(";")[0] : "";
     }
     if (isDetailed) {
+        // The XML parser tries to interpret values, but the display name is required to be a string
+        if (props.displayname !== undefined) {
+            props.displayname = String(props.displayname);
+        }
         stat.props = props;
     }
     return stat;

--- a/test/node/operations/getDirectoryContents.spec.ts
+++ b/test/node/operations/getDirectoryContents.spec.ts
@@ -136,6 +136,22 @@ describe("getDirectoryContents", function () {
         });
     });
 
+    it("correctly parses the displayname property", function () {
+        returnFakeResponse(
+            readFileSync(
+                new URL("../../responses/propfind-numeric-displayname.xml", import.meta.url)
+            ).toString()
+        );
+        return this.client.getDirectoryContents("/1", { details: true }).then(function (result) {
+            expect(result.data).to.have.length(1);
+            expect(result.data[0]).to.have.property("props").that.is.an("object");
+            expect(result.data[0].props)
+                .to.have.property("displayname")
+                .that.is.a("string")
+                .and.equal("1");
+        });
+    });
+
     it("returns the contents of a directory with repetitive naming", function () {
         return this.client.getDirectoryContents("/webdav/server").then(function (contents) {
             expect(contents).to.be.an("array");

--- a/test/node/operations/stat.spec.ts
+++ b/test/node/operations/stat.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { readFileSync } from "fs";
 import { WebDAVClientError } from "../../../source/types.js";
 import {
     SERVER_PASSWORD,
@@ -8,7 +9,8 @@ import {
     createWebDAVClient,
     createWebDAVServer,
     useCustomXmlResponse,
-    restoreRequests
+    restoreRequests,
+    returnFakeResponse
 } from "../../helpers.node.js";
 
 describe("stat", function () {
@@ -109,6 +111,22 @@ describe("stat", function () {
             }
             expect(error).to.not.be.null;
             expect(error.status).to.equal(404);
+        });
+    });
+
+    it("correctly parses the displayname property", function () {
+        returnFakeResponse(
+            readFileSync(
+                new URL("../../responses/propfind-numeric-displayname.xml", import.meta.url)
+            ).toString()
+        );
+
+        this.client.stat("/1/", { details: true }).then(function (result) {
+            expect(result.data).to.have.property("props").that.is.an("object");
+            expect(result.data.props)
+                .to.have.property("displayname")
+                .that.is.a("string")
+                .and.equal("1");
         });
     });
 

--- a/test/responses/propfind-numeric-displayname.xml
+++ b/test/responses/propfind-numeric-displayname.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<d:multistatus
+	xmlns:d="DAV:">
+	<d:response>
+		<d:href>/remote.php/dav/files/admin/1/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getetag>&quot;66a15a0171527&quot;</d:getetag>
+				<d:getlastmodified>Wed, 24 Jul 2024 19:46:09 GMT</d:getlastmodified>
+				<d:creationdate>1970-01-01T00:00:00+00:00</d:creationdate>
+				<d:displayname>1</d:displayname>
+				<d:quota-available-bytes>-3</d:quota-available-bytes>
+				<d:resourcetype>
+					<d:collection/>
+				</d:resourcetype>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength/>
+				<d:getcontenttype/>
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+</d:multistatus>


### PR DESCRIPTION
In case e.g. a directory is called `1` the XML parser will convert the display name to a number. This is against the types and not expected behavior.