### PR TITLE
feat: Allow to register prop and attribute parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ function jsonPropParser(jPath: string, value: string) {
         return JSON.parse(value)
     }
     // Apply default parsing otherwise
-    return value
+    return value;
 }
 await client.registerTagParser(jsonPropParser);
 ```

--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ Register a new attribute parser on the client
 // Parses all `disabled` attributes to boolean, e.g. `<prop disabled="true">`
 function booleanAttributeParser(jPath: string, value: string) {
     if (jPath.endsWith(".disabled")) {
-        return value === "true"
+        return value === "true";
     }
     // Apply default parsing otherwise
     return value

--- a/README.md
+++ b/README.md
@@ -677,6 +677,64 @@ await client.unlock("/file.doc", lock.token);
 
 _`options` extends [method options](#method-options)._
 
+#### registerAttributeParser
+
+Register a new attribute parser on the client
+
+```typescript
+// Parses all `disabled` attributes to boolean, e.g. `<prop disabled="true">`
+function booleanAttributeParser(jPath: string, value: string) {
+    if (jPath.endsWith(".disabled")) {
+        return value === "true"
+    }
+    // Apply default parsing otherwise
+    return value
+}
+await client.registerAttributeParser(booleanAttributeParser);
+```
+
+```typescript
+(parser: WebDAVAttributeParser) => void
+```
+
+The `WebDAVAttributeParser` is a function that receives the jPath and the attribute value and either returns:
+- `undefined` to use the value as it is and skip any further parsing
+- the unchanged value to apply default parsing
+- Any other parsed value to use
+
+```typescript
+(jPath: string, value: string) => undefined|string|unknown
+```
+
+#### registerTagParser
+
+Register a new tag parser on the client, this is used to parse the value of props when doing stat requests.
+
+```typescript
+// Parses only <prop><json-prop>JSONVALUE</json-prop></prop>
+function jsonPropParser(jPath: string, value: string) {
+    if (jPath.endsWith("prop.json-prop")) {
+        return JSON.parse(value)
+    }
+    // Apply default parsing otherwise
+    return value
+}
+await client.registerTagParser(jsonPropParser);
+```
+
+```typescript
+(parser: WebDAVTagParser) => void
+```
+
+The `WebDAVTagParser` is a function that receives the jPath and the attribute value and either returns:
+- `undefined` to use the value as it is and skip any further parsing
+- the unchanged value to apply default parsing
+- Any other parsed value to use
+
+```typescript
+(jPath: string, value: string) => undefined|string|unknown
+```
+
 ##### Custom properties
 
 For requests like `stat`, which use the `PROPFIND` method under the hood, it is possible to provide a custom request body to the method so that the server may respond with additional/different data. Overriding of the body can be performed by setting the `data` property in the [method options](#method-options).

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ The available configuration options are as follows:
 | Option        | Default       | Description                                       |
 |---------------|---------------|---------------------------------------------------|
 | `authType`    | `null`        | The authentication type to use. If not provided, defaults to trying to detect based upon whether `username` and `password` were provided. |
+| `attributeNamePrefix` | `@`   | Prefix used to identify attributes on the property object |
 | `contactHref` | _[This URL](https://github.com/perry-mitchell/webdav-client/blob/master/LOCK_CONTACT.md)_ | Contact URL used for LOCKs. |
 | `headers`     | `{}`          | Additional headers provided to all requests. Headers provided here are overridden by method-specific headers, including `Authorization`. |
 | `httpAgent`   | _None_        | HTTP agent instance. Available only in Node. See [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent). |
@@ -694,7 +695,7 @@ Most WebDAV methods extend `WebDAVMethodOptions`, which allow setting things lik
 
 #### Item stats
 
-Item stats are objects with properties that descibe a file or directory. They resemble the following:
+Item stats are objects with properties that describe a file or directory. They resemble the following:
 
 ```json
 {
@@ -745,6 +746,46 @@ Requests that return results, such as `getDirectoryContents`, `getFileContents`,
 | headers      | Object          | The response headers.                  |
 | status       | Number          | The numeric status code.               |
 | statusText   | String          | The status text.                       |
+
+One example could look like this, in this example the `system-tag` prop contained attributes which you can identifiy by the `attributeNamePrefix` (by default `@`), the value is then contained in the `text` attribute:
+
+```json
+{
+    "headers": {},
+    "status": 200,
+    "statusText": "Ok",
+    "data": {
+        "filename": "/1",
+        "basename": "1",
+        "lastmod": "Wed, 24 Jul 2024 19:46:09 GMT",
+        "size": 0,
+        "type": "file",
+        "etag": "66a15a0171527",
+        "mime": "",
+        "props": {
+            "getetag": "\"66a15a0171527\"",
+            "getlastmodified": "Wed, 24 Jul 2024 19:46:09 GMT",
+            "creationdate": "1970-01-01T00:00:00+00:00",
+            "system-tags": {
+                "system-tag": [
+                    {
+                        "text": "Tag1",
+                        "@can-assign": "true",
+                        "@id": "321",
+                        "@checked": true
+                    },
+                    {
+                        "text": "Tag2",
+                        "@can-assign": "false",
+                        "@id": "654",
+                        "@prop": ""
+                    }
+                ]
+            }
+        }
+    },
+}
+```
 
 ### CORS
 CORS is a security enforcement technique employed by browsers to ensure requests are executed to and from expected contexts. It can conflict with this library if the target server doesn't return CORS headers when making requests from a browser. It is your responsibility to handle this.

--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ Requests that return results, such as `getDirectoryContents`, `getFileContents`,
 | status       | Number          | The numeric status code.               |
 | statusText   | String          | The status text.                       |
 
-One example could look like this, in this example the `system-tag` prop contained attributes which you can identifiy by the `attributeNamePrefix` (by default `@`), the value is then contained in the `text` attribute:
+In the following example the `system-tag` prop contained attributes which you can identify by providing the `attributeNamePrefix` (by default `@`), with the value is then contained in the `text` attribute:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ Register a new tag parser on the client, this is used to parse the value of prop
 // Parses only <prop><json-prop>JSONVALUE</json-prop></prop>
 function jsonPropParser(jPath: string, value: string) {
     if (jPath.endsWith("prop.json-prop")) {
-        return JSON.parse(value)
+        return JSON.parse(value);
     }
     // Apply default parsing otherwise
     return value;

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ function booleanAttributeParser(jPath: string, value: string) {
         return value === "true";
     }
     // Apply default parsing otherwise
-    return value
+    return value;
 }
 await client.registerAttributeParser(booleanAttributeParser);
 ```

--- a/source/factory.ts
+++ b/source/factory.ts
@@ -70,6 +70,9 @@ export function createClient(remoteURL: string, options: WebDAVClientOptions = {
         httpAgent,
         httpsAgent,
         password,
+        parsing: {
+            attributeNamePrefix: options.attributeNamePrefix ?? "@"
+        },
         remotePath: extractURLPath(remoteURL),
         remoteURL,
         token,

--- a/source/factory.ts
+++ b/source/factory.ts
@@ -17,6 +17,7 @@ import { moveFile } from "./operations/moveFile.js";
 import { getFileUploadLink, putFileContents } from "./operations/putFileContents.js";
 import { partialUpdateFileContents } from "./operations/partialUpdateFileContents.js";
 import { getDAVCompliance } from "./operations/getDAVCompliance.js";
+import { displaynameTagParser } from "./tools/dav.js";
 import {
     AuthType,
     BufferLike,
@@ -34,10 +35,12 @@ import {
     RequestOptionsCustom,
     SearchOptions,
     StatOptions,
+    WebDAVAttributeParser,
     WebDAVClient,
     WebDAVClientContext,
     WebDAVClientOptions,
-    WebDAVMethodOptions
+    WebDAVMethodOptions,
+    WebDAVTagParser
 } from "./types.js";
 
 const DEFAULT_CONTACT_HREF =
@@ -71,7 +74,9 @@ export function createClient(remoteURL: string, options: WebDAVClientOptions = {
         httpsAgent,
         password,
         parsing: {
-            attributeNamePrefix: options.attributeNamePrefix ?? "@"
+            attributeNamePrefix: options.attributeNamePrefix ?? "@",
+            attributeParsers: [],
+            tagParsers: [displaynameTagParser]
         },
         remotePath: extractURLPath(remoteURL),
         remoteURL,
@@ -127,6 +132,12 @@ export function createClient(remoteURL: string, options: WebDAVClientOptions = {
         },
         stat: (path: string, options?: StatOptions) => getStat(context, path, options),
         unlock: (path: string, token: string, options?: WebDAVMethodOptions) =>
-            unlock(context, path, token, options)
+            unlock(context, path, token, options),
+        registerAttributeParser: (parser: WebDAVAttributeParser) => {
+            context.parsing.attributeParsers.push(parser);
+        },
+        registerTagParser: (parser: WebDAVTagParser) => {
+            context.parsing.tagParsers.push(parser);
+        }
     };
 }

--- a/source/operations/directoryContents.ts
+++ b/source/operations/directoryContents.ts
@@ -35,7 +35,7 @@ export async function getDirectoryContents(
     if (!responseData) {
         throw new Error("Failed parsing directory contents: Empty response");
     }
-    const davResp = await parseXML(responseData);
+    const davResp = await parseXML(responseData, context.parsing);
     const _remotePath = makePathAbsolute(remotePath);
     const remoteBasePath = makePathAbsolute(context.remoteBasePath || context.remotePath);
     let files = getDirectoryFiles(

--- a/source/operations/getQuota.ts
+++ b/source/operations/getQuota.ts
@@ -25,7 +25,7 @@ export async function getQuota(
     const response = await request(requestOptions, context);
     handleResponseCode(context, response);
     const responseData = await response.text();
-    const result = await parseXML(responseData);
+    const result = await parseXML(responseData, context.parsing);
     const quota = parseQuota(result);
     return processResponsePayload(response, quota, options.details);
 }

--- a/source/operations/search.ts
+++ b/source/operations/search.ts
@@ -32,7 +32,7 @@ export async function getSearch(
     const response = await request(requestOptions, context);
     handleResponseCode(context, response);
     const responseText = await response.text();
-    const responseData = await parseXML(responseText);
+    const responseData = await parseXML(responseText, context.parsing);
     const results = parseSearch(responseData, searchArbiter, isDetailed);
     return processResponsePayload(response, results, isDetailed);
 }

--- a/source/operations/stat.ts
+++ b/source/operations/stat.ts
@@ -26,7 +26,7 @@ export async function getStat(
     const response = await request(requestOptions, context);
     handleResponseCode(context, response);
     const responseData = await response.text();
-    const result = await parseXML(responseData);
+    const result = await parseXML(responseData, context.parsing);
     const stat = parseStat(result, filename, isDetailed);
     return processResponsePayload(response, stat, isDetailed);
 }

--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -1,7 +1,6 @@
 import path from "path-posix";
 import { XMLParser } from "fast-xml-parser";
 import nestedProp from "nested-property";
-import { decodeHTMLEntities } from "./encode.js";
 import { encodePath, normalisePath } from "./path.js";
 import {
     DAVResult,
@@ -21,10 +20,10 @@ enum PropertyType {
     Original = "original"
 }
 
-function getParser(): XMLParser {
+function getParser({ attributeNamePrefix }): XMLParser {
     return new XMLParser({
         allowBooleanAttributes: true,
-        attributeNamePrefix: "",
+        attributeNamePrefix,
         textNodeName: "text",
         ignoreAttributes: false,
         removeNSPrefix: true,
@@ -117,11 +116,12 @@ function normaliseResult(result: DAVResultRaw): DAVResult {
  * Parse an XML response from a WebDAV service,
  *  converting it to an internal DAV result
  * @param xml The raw XML string
+ * @param context The current client context
  * @returns A parsed and processed DAV result
  */
-export function parseXML(xml: string): Promise<DAVResult> {
+export function parseXML(xml: string, context: WebDAVParsingContext): Promise<DAVResult> {
     return new Promise(resolve => {
-        const result = getParser().parse(xml);
+        const result = getParser(context).parse(xml);
         resolve(normaliseResult(result));
     });
 }

--- a/source/types.ts
+++ b/source/types.ts
@@ -316,6 +316,8 @@ export interface WebDAVClient {
         options?: StatOptions
     ) => Promise<FileStat | ResponseDataDetailed<FileStat>>;
     unlock: (path: string, token: string, options?: WebDAVMethodOptions) => Promise<void>;
+    registerAttributeParser: (parser: WebDAVAttributeParser) => void;
+    registerTagParser: (parser: WebDAVTagParser) => void;
 }
 
 export interface WebDAVClientContext {
@@ -364,6 +366,27 @@ export interface WebDAVMethodOptions {
     signal?: AbortSignal;
 }
 
+/**
+ * Callback to parse a prop attribute value.
+ * If `undefined` is returned the original text value will be used.
+ * If the unchanged value is returned the default parsing will be applied.
+ * Otherwise the returned value will be used.
+ */
+export type WebDAVAttributeParser = (
+    jPath: string,
+    attributeValue: string
+) => string | unknown | undefined;
+
+/**
+ * Callback to parse a prop tag value.
+ * If `undefined` is returned the original text value will be used.
+ * If the unchanged value is returned the default parsing will be applied.
+ * Otherwise the returned value will be used.
+ */
+export type WebDAVTagParser = (jPath: string, tagValue: string) => string | unknown | undefined;
+
 export interface WebDAVParsingContext {
     attributeNamePrefix?: string;
+    attributeParsers: WebDAVAttributeParser[];
+    tagParsers: WebDAVTagParser[];
 }

--- a/source/types.ts
+++ b/source/types.ts
@@ -327,6 +327,7 @@ export interface WebDAVClientContext {
     headers: Headers;
     httpAgent?: any;
     httpsAgent?: any;
+    parsing: WebDAVParsingContext;
     password?: string;
     remotePath: string;
     remoteURL: string;
@@ -341,6 +342,7 @@ export interface WebDAVClientError extends Error {
 }
 
 export interface WebDAVClientOptions {
+    attributeNamePrefix?: string;
     authType?: AuthType;
     remoteBasePath?: string;
     contactHref?: string;
@@ -360,4 +362,8 @@ export interface WebDAVMethodOptions {
     data?: RequestDataPayload;
     headers?: Headers;
     signal?: AbortSignal;
+}
+
+export interface WebDAVParsingContext {
+    attributeNamePrefix?: string;
 }

--- a/test/node/operations/stat.spec.ts
+++ b/test/node/operations/stat.spec.ts
@@ -147,15 +147,15 @@ describe("stat", function () {
             // <z:system-tag z:can-assign="false" z:id="654" z:prop="">Tag2</z:system-tag>
             expect(result.data.props["system-tags"]["system-tag"]).to.deep.equal([
                 {
-                    "can-assign": true,
-                    id: "321",
-                    checked: true,
+                    "@can-assign": "true",
+                    "@id": "321",
+                    "@checked": true,
                     text: "Tag1"
                 },
                 {
-                    "can-assign": false,
-                    id: "654",
-                    prop: "",
+                    "@can-assign": "false",
+                    "@id": "654",
+                    "@prop": "",
                     text: "Tag2"
                 }
             ]);

--- a/test/node/tools/dav.spec.ts
+++ b/test/node/tools/dav.spec.ts
@@ -12,4 +12,70 @@ describe("parseXML", function () {
         // Ensure trailing zero is not lost
         expect(parsed.multistatus.response[0].propstat.prop.displayname).to.equal("2024.10");
     });
+
+    it("correctly parses property attributes", async function () {
+        const data = await readFile(
+            new URL("../../responses/propfind-attributes.xml", import.meta.url)
+        );
+
+        const parsed = await parseXML(data.toString());
+
+        expect(parsed.multistatus.response).to.have.length(1);
+        expect(
+            parsed.multistatus.response[0].propstat.prop["system-tags"]["system-tag"]
+        ).to.deep.equal([
+            {
+                "@can-assign": "true",
+                "@id": "321",
+                "@checked": true,
+                text: "Tag1"
+            },
+            {
+                "@can-assign": "false",
+                "@id": "654",
+                "@prop": "",
+                text: "Tag2"
+            }
+        ]);
+    });
+
+    it("parses property attributes with different prefix", async function () {
+        const data = await readFile(
+            new URL("../../responses/propfind-attributes.xml", import.meta.url)
+        );
+
+        const parsed = await parseXML(data.toString(), { attributeNamePrefix: "" });
+
+        expect(parsed.multistatus.response).to.have.length(1);
+        expect(
+            parsed.multistatus.response[0].propstat.prop["system-tags"]["system-tag"]
+        ).to.deep.equal([
+            {
+                "can-assign": "true",
+                id: "321",
+                checked: true,
+                text: "Tag1"
+            },
+            {
+                "can-assign": "false",
+                id: "654",
+                prop: "",
+                text: "Tag2"
+            }
+        ]);
+    });
+
+    it("correctly parses property attributes that have the same name as nested prop", async function () {
+        const data = await readFile(
+            new URL("../../responses/propfind-attributes-conflict.xml", import.meta.url)
+        );
+
+        const parsed = await parseXML(data.toString());
+
+        expect(parsed.multistatus.response).to.have.length(1);
+        expect(parsed.multistatus.response[0].propstat.prop.prop).to.deep.equal({
+            "@link": "value",
+            link: "text value"
+        });
+    });
 });

--- a/test/node/tools/dav.spec.ts
+++ b/test/node/tools/dav.spec.ts
@@ -44,7 +44,11 @@ describe("parseXML", function () {
             new URL("../../responses/propfind-attributes.xml", import.meta.url)
         );
 
-        const parsed = await parseXML(data.toString(), { attributeNamePrefix: "" });
+        const parsed = await parseXML(data.toString(), {
+            attributeNamePrefix: "",
+            attributeParsers: [],
+            tagParsers: []
+        });
 
         expect(parsed.multistatus.response).to.have.length(1);
         expect(
@@ -65,6 +69,44 @@ describe("parseXML", function () {
         ]);
     });
 
+    it("parses property attributes with custom parser", async function () {
+        // Dummy parser that parses all string "true" or "false" to the boolean value
+        const booleanAttributeParser = (path: string, value: string) => {
+            if (["true", "false"].includes(value)) {
+                return value === "true";
+            }
+            return value;
+        };
+
+        const data = await readFile(
+            new URL("../../responses/propfind-attributes.xml", import.meta.url)
+        );
+
+        const parsed = await parseXML(data.toString(), {
+            attributeNamePrefix: "",
+            attributeParsers: [booleanAttributeParser],
+            tagParsers: []
+        });
+
+        expect(parsed.multistatus.response).to.have.length(1);
+        expect(
+            parsed.multistatus.response[0].propstat.prop["system-tags"]["system-tag"]
+        ).to.deep.equal([
+            {
+                "can-assign": true,
+                id: "321",
+                checked: true,
+                text: "Tag1"
+            },
+            {
+                "can-assign": false,
+                id: "654",
+                prop: "",
+                text: "Tag2"
+            }
+        ]);
+    });
+
     it("correctly parses property attributes that have the same name as nested prop", async function () {
         const data = await readFile(
             new URL("../../responses/propfind-attributes-conflict.xml", import.meta.url)
@@ -77,5 +119,34 @@ describe("parseXML", function () {
             "@link": "value",
             link: "text value"
         });
+    });
+
+    it("parses props with custom parser", async function () {
+        // Dummy parser that parses all string "true" or "false" to the boolean value
+        const shareAttributesParser = (path: string, value: string) => {
+            if (path.endsWith("prop.share-attributes")) {
+                return JSON.parse(value);
+            }
+            return value;
+        };
+
+        const data = await readFile(
+            new URL("../../responses/propfind-nextcloud-share-attributes.xml", import.meta.url)
+        );
+
+        const parsed = await parseXML(data.toString(), {
+            attributeNamePrefix: "",
+            attributeParsers: [],
+            tagParsers: [shareAttributesParser]
+        });
+
+        expect(parsed.multistatus.response).to.have.length(1);
+        expect(parsed.multistatus.response[0].propstat.prop["share-attributes"]).to.deep.equal([
+            {
+                scope: "permissions",
+                key: "download",
+                value: false
+            }
+        ]);
     });
 });

--- a/test/responses/propfind-attributes-conflict.xml
+++ b/test/responses/propfind-attributes-conflict.xml
@@ -9,10 +9,9 @@
 				<d:getetag>&quot;66a15a0171527&quot;</d:getetag>
 				<d:getlastmodified>Wed, 24 Jul 2024 19:46:09 GMT</d:getlastmodified>
 				<d:creationdate>1970-01-01T00:00:00+00:00</d:creationdate>
-				<z:system-tags>
-					<z:system-tag z:can-assign="true" z:id="321" z:checked>Tag1</z:system-tag>
-					<z:system-tag z:can-assign="false" z:id="654" z:prop="">Tag2</z:system-tag>
-				</z:system-tags>
+				<z:prop z:link="value">
+					<z:link>text value</z:link>
+				</z:prop>
 			</d:prop>
 			<d:status>HTTP/1.1 200 OK</d:status>
 		</d:propstat>

--- a/test/responses/propfind-nextcloud-share-attributes.xml
+++ b/test/responses/propfind-nextcloud-share-attributes.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns"
+	xmlns:nc="http://nextcloud.org/ns">
+	<d:response>
+		<d:href>/remote.php/dav/files/user1/New%20folder/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getetag>&quot;67ada8c90025b&quot;</d:getetag>
+				<d:getlastmodified>Thu, 13 Feb 2025 08:09:44 GMT</d:getlastmodified>
+				<d:creationdate>1970-01-01T00:00:00+00:00</d:creationdate>
+				<d:displayname>New folder</d:displayname>
+				<d:quota-available-bytes>-3</d:quota-available-bytes>
+				<d:resourcetype>
+					<d:collection />
+				</d:resourcetype>
+				<nc:has-preview>false</nc:has-preview>
+				<nc:mount-type>shared</nc:mount-type>
+				<oc:comments-unread>0</oc:comments-unread>
+				<oc:favorite>0</oc:favorite>
+				<oc:fileid>56</oc:fileid>
+				<oc:owner-display-name>admin</oc:owner-display-name>
+				<oc:owner-id>admin</oc:owner-id>
+				<oc:permissions>SRGDNVCK</oc:permissions>
+				<oc:size>292842</oc:size>
+				<nc:hidden>false</nc:hidden>
+				<nc:is-mount-root>true</nc:is-mount-root>
+				<nc:reminder-due-date></nc:reminder-due-date>
+				<nc:note></nc:note>
+				<nc:sharees />
+				<nc:share-attributes>
+					[{&quot;scope&quot;:&quot;permissions&quot;,&quot;key&quot;:&quot;download&quot;,&quot;value&quot;:false}]</nc:share-attributes>
+				<oc:share-types />
+				<x1:share-permissions xmlns:x1="http://open-collaboration-services.org/ns">31</x1:share-permissions>
+				<nc:system-tags />
+				<nc:rich-workspace></nc:rich-workspace>
+				<nc:rich-workspace-file></nc:rich-workspace-file>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength />
+				<d:getcontenttype />
+				<nc:is-encrypted />
+				<nc:metadata-blurhash />
+				<nc:metadata-files-live-photo />
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+</d:multistatus>


### PR DESCRIPTION
This consists of two changes:

1. A fix for https://github.com/perry-mitchell/webdav-client/pull/391#issuecomment-2649178022
   **Allow to configure a tag prefix.**
   Without a prefix there can be name clashes between attributes and child
    tags. For example `<tag id="A"><id>B</id></tag>` will not be parsed to
    contain both the tag `id` and the attribute `id` but one will overwrite
    the other.
2. Allow to register custom parsers for attributes and props, so we do not always do automatic numeric parsing leading to issues like we had with the `displayname`, see the examples in the added tests on how this could be useful.