### PR TITLE
feat: opt-in Clark-notation prop keys for namespace disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,25 @@ const client = createClient("https://some-server.org", {
 | `limit.maxTotalExpansions` | `0` | Maximum number of entity references expanded per document. `0` means unlimited. |
 | `limit.maxExpandedLength`  | `0` | Maximum number of characters added by entity expansion per document. `0` means unlimited. |
 
+### Namespaced property keys
+
+Property keys are reported by their local name, so two properties sharing a local name across different XML namespaces collapse into one key. Passing `clarkNotationProps` to the exported `parseXML` keys them in [Clark notation](http://www.jclark.com/xml/xmlns.htm) (`{namespaceURI}localName`) instead, which keeps them apart and gives a property the same key regardless of whether the server used a prefix or an inline `xmlns`:
+
+```typescript
+import { parseXML } from "webdav";
+
+const result = await parseXML(xml, {
+    attributeNamePrefix: "@",
+    attributeParsers: [],
+    clarkNotationProps: true,
+    tagParsers: []
+});
+// { "{DAV:}displayname": "file.txt", "{http://owncloud.org/ns}permissions": "RDNVW" }
+const props = result.multistatus.response[0].propstat.prop;
+```
+
+This is a low-level option for consumers parsing responses themselves: it is not available on `createClient`, as the client methods (`stat`, `getDirectoryContents`, `search`, `getQuota`) read bare property keys. Only the direct children of `<prop>` are rewritten, and a property whose prefix has no namespace declaration in scope keeps its bare local name.
+
 ### Client methods
 
 The `WebDAVClient` interface type contains all the methods and signatures for the WebDAV client instance.

--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -187,11 +187,6 @@ const STRUCTURAL_KEYS = new Set([
     "responsedescription"
 ]);
 
-function localName(key: string): string {
-    const colonIdx = key.indexOf(":");
-    return colonIdx === -1 ? key : key.slice(colonIdx + 1);
-}
-
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -204,19 +199,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  *  2. Rewrite every key inside each `<prop>` to Clark notation
  *     `{namespaceURI}localName`, resolving the namespace from the xmlns
  *     scope of the surrounding multistatus and from any inline
- *     `xmlns="..."` declared on the property element itself. Wrapped values
- *     of the form `{ "@xmlns": ..., text: "..." }` are unwrapped to just
- *     their text content.
- *
- * Pre-computes the xmlns attribute keys once and extends the prefix scope
- * map only when a node actually declares xmlns, so the walk stays close to
- * a plain tree traversal in cost.
+ *     `xmlns="..."` declared on the property element itself. Wrapped
+ *     simple-text elements of the form `{ "@xmlns": ..., text: "..." }`
+ *     are unwrapped to their text content. Property values with their own
+ *     nested element children are returned as-is (the keys of those
+ *     grandchildren are not rewritten to Clark notation).
  */
 function applyClarkNotation(root: unknown, attrPrefix: string): void {
     if (!isPlainObject(root) && !Array.isArray(root)) return;
 
-    // Stable string references for the duration of the walk; lets V8
-    // inline-cache the property accesses against the same key shapes.
     const xmlnsKey = `${attrPrefix}xmlns`;
     const xmlnsPrefixedKey = `${xmlnsKey}:`;
     const xmlnsPrefixedKeyLen = xmlnsPrefixedKey.length;
@@ -249,26 +240,19 @@ function applyClarkNotation(root: unknown, attrPrefix: string): void {
         return scope ?? parent;
     }
 
+    // Unwrap the `{ "@xmlns": ..., text: "..." }` shape that fast-xml-parser
+    // produces for elements with both an xmlns attribute and text content.
+    // Complex elements with their own nested children are returned as-is:
+    // their keys are NOT rewritten to Clark notation, since the walker only
+    // resolves namespaces at the `<prop>` child level.
     function unwrapXmlnsWrappedValue(raw: unknown): unknown {
         if (!isPlainObject(raw)) return raw;
         const text = raw[TEXT_KEY];
-        // If the only non-text keys are xmlns attrs, the element is a simple
-        // text node with namespace metadata: extract the text directly.
-        let onlyXmlnsAndText = true;
         for (const k of Object.keys(raw)) {
             if (k === TEXT_KEY) continue;
-            if (!isXmlnsAttr(k)) {
-                onlyXmlnsAndText = false;
-                break;
-            }
+            if (!isXmlnsAttr(k)) return raw;
         }
-        if (onlyXmlnsAndText && text !== undefined) return text;
-        // Complex element: clone with xmlns attrs stripped, keep child content.
-        const out: Record<string, unknown> = {};
-        for (const k of Object.keys(raw)) {
-            if (!isXmlnsAttr(k)) out[k] = raw[k];
-        }
-        return out;
+        return text !== undefined ? text : raw;
     }
 
     function emitClarkForChild(
@@ -335,7 +319,8 @@ function applyClarkNotation(root: unknown, attrPrefix: string): void {
         const childScope = extendScope(node, scope);
 
         for (const key of Object.keys(node)) {
-            const ln = localName(key);
+            const colonIdx = key.indexOf(":");
+            const ln = colonIdx === -1 ? key : key.slice(colonIdx + 1);
             const value = node[key];
 
             // Rename structural keys to bare local name.

--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -23,13 +23,26 @@ enum PropertyType {
     Original = "original"
 }
 
-function toJPathString(
-    jPath: string | { toString: (sep?: string, includeNS?: boolean) => string }
-): string {
+type JPath = string | { toArray: () => string[] };
+
+function stripPrefix(name: string): string {
+    const colonIdx = name.indexOf(":");
+    return colonIdx === -1 ? name : name.slice(colonIdx + 1);
+}
+
+function isXmlnsAttribute(name: string): boolean {
+    return name === "xmlns" || name.startsWith("xmlns:");
+}
+
+// The parser only keeps namespace prefixes on tags in Clark mode, so without
+// this the jPaths would be `d:propstat.d:prop.d:displayname` there and bare
+// everywhere else. Strip per segment (rather than off the joined path) as
+// prefixes and local names may both contain dots.
+function toJPathString(jPath: JPath): string {
     if (typeof jPath === "string") {
         return jPath;
     }
-    return jPath.toString(".", false);
+    return jPath.toArray().map(stripPrefix).join(".");
 }
 
 function getParser({
@@ -50,7 +63,13 @@ function getParser({
             hex: true,
             leadingZeros: false
         },
-        attributeValueProcessor(_, attrValue, jPath) {
+        attributeValueProcessor(attrName, attrValue, jPath) {
+            // Clark mode keeps the namespace declarations, which the default
+            // mode discards. They are consumed by the walker and removed from
+            // the result, so parsers never get to see them in either mode.
+            if (attributeParsers.length === 0 || isXmlnsAttribute(attrName)) {
+                return attrValue;
+            }
             const pathStr = toJPathString(jPath);
             for (const processor of attributeParsers) {
                 try {
@@ -65,6 +84,9 @@ function getParser({
             return attrValue;
         },
         tagValueProcessor(tagName, tagValue, jPath) {
+            if (tagParsers.length === 0) {
+                return tagValue;
+            }
             const pathStr = toJPathString(jPath);
             for (const processor of tagParsers) {
                 try {
@@ -197,13 +219,16 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  *  1. Rename structural keys (`multistatus`/`response`/...) back to their
  *     bare local names so `DAVResult`'s shape is preserved.
  *  2. Rewrite every key inside each `<prop>` to Clark notation
- *     `{namespaceURI}localName`, resolving the namespace from the xmlns
- *     scope of the surrounding multistatus and from any inline
- *     `xmlns="..."` declared on the property element itself. Wrapped
- *     simple-text elements of the form `{ "@xmlns": ..., text: "..." }`
- *     are unwrapped to their text content. Property values with their own
- *     nested element children are returned as-is (the keys of those
- *     grandchildren are not rewritten to Clark notation).
+ *     `{namespaceURI}localName`, resolving the namespace against the xmlns
+ *     scope built up along the way (declarations on any of the enclosing
+ *     elements as well as on the property element itself). A property whose
+ *     prefix has no URI in scope keeps its bare local name.
+ *  3. Drop the xmlns declarations once they are resolved, so the result
+ *     carries the same shape the default (prefix-stripping) mode produces.
+ *
+ * Only the direct children of `<prop>` are rewritten: the keys of any
+ * nested elements below them are left alone and keep whichever prefix the
+ * server serialised them with.
  */
 function applyClarkNotation(root: unknown, attrPrefix: string): void {
     if (!isPlainObject(root) && !Array.isArray(root)) return;
@@ -240,19 +265,25 @@ function applyClarkNotation(root: unknown, attrPrefix: string): void {
         return scope ?? parent;
     }
 
-    // Unwrap the `{ "@xmlns": ..., text: "..." }` shape that fast-xml-parser
-    // produces for elements with both an xmlns attribute and text content.
-    // Complex elements with their own nested children are returned as-is:
-    // their keys are NOT rewritten to Clark notation, since the walker only
-    // resolves namespaces at the `<prop>` child level.
-    function unwrapXmlnsWrappedValue(raw: unknown): unknown {
+    // Drop the namespace declarations once they have been resolved, so a prop
+    // value ends up with the same shape it has in the default (prefix-
+    // stripping) mode: bare text for a simple element, an empty string for an
+    // empty one, and `{ text, "@attr" }` for one carrying other attributes.
+    // The keys of nested children are NOT rewritten to Clark notation, since
+    // the walker only resolves namespaces at the `<prop>` child level; those
+    // keep the prefix the server happened to serialise them with.
+    function cleanPropValue(raw: unknown): unknown {
+        if (Array.isArray(raw)) return raw.map(cleanPropValue);
         if (!isPlainObject(raw)) return raw;
-        const text = raw[TEXT_KEY];
-        for (const k of Object.keys(raw)) {
-            if (k === TEXT_KEY) continue;
-            if (!isXmlnsAttr(k)) return raw;
+        const out: Record<string, unknown> = {};
+        for (const key of Object.keys(raw)) {
+            if (isXmlnsAttr(key)) continue;
+            out[key] = cleanPropValue(raw[key]);
         }
-        return text !== undefined ? text : raw;
+        const keys = Object.keys(out);
+        if (keys.length === 0) return "";
+        if (keys.length === 1 && keys[0] === TEXT_KEY) return out[TEXT_KEY];
+        return out;
     }
 
     function emitClarkForChild(
@@ -264,9 +295,16 @@ function applyClarkNotation(root: unknown, attrPrefix: string): void {
         const colonIdx = rawKey.indexOf(":");
         const prefix = colonIdx === -1 ? "" : rawKey.slice(0, colonIdx);
         const local = colonIdx === -1 ? rawKey : rawKey.slice(colonIdx + 1);
-        // Unknown prefix falls back to the null namespace; that yields a bare
-        // `local` key rather than throwing or losing the data.
-        const scopeNs = scope.get(prefix) ?? "";
+
+        // A property element may declare its own namespaces, either as a
+        // default `xmlns="..."` or bound to the very prefix it uses, so its
+        // attributes have to be folded into the scope before resolving. A
+        // prefix with no URI in scope falls back to the null namespace; that
+        // yields a bare `local` key rather than throwing or losing the data.
+        const resolveNs = (value: unknown): string => {
+            const ownScope = isPlainObject(value) ? extendScope(value, scope) : scope;
+            return ownScope.get(prefix) ?? "";
+        };
 
         const assign = (ns: string, value: unknown): void => {
             const key = ns ? `{${ns}}${local}` : local;
@@ -282,18 +320,12 @@ function applyClarkNotation(root: unknown, attrPrefix: string): void {
 
         if (Array.isArray(rawValue)) {
             for (const item of rawValue) {
-                const itemNs =
-                    isPlainObject(item) && xmlnsKey in item ? (item[xmlnsKey] as string) : scopeNs;
-                assign(itemNs, unwrapXmlnsWrappedValue(item));
+                assign(resolveNs(item), cleanPropValue(item));
             }
             return;
         }
 
-        const ns =
-            isPlainObject(rawValue) && xmlnsKey in rawValue
-                ? (rawValue[xmlnsKey] as string)
-                : scopeNs;
-        assign(ns, unwrapXmlnsWrappedValue(rawValue));
+        assign(resolveNs(rawValue), cleanPropValue(rawValue));
     }
 
     function rewritePropToClark(
@@ -309,16 +341,34 @@ function applyClarkNotation(root: unknown, attrPrefix: string): void {
         return out;
     }
 
-    function walk(node: unknown, scope: Map<string, string>): void {
+    function rewriteProp(value: unknown, parentScope: Map<string, string>): unknown {
+        if (!isPlainObject(value)) return value;
+        const rewritten = rewritePropToClark(value, parentScope);
+        return Object.keys(rewritten).length === 0 ? "" : rewritten;
+    }
+
+    // Returns the (possibly replaced) node, so that an element left empty by
+    // dropping its namespace declarations collapses to the empty string the
+    // default mode would have produced for it.
+    function walk(node: unknown, scope: Map<string, string>): unknown {
         if (Array.isArray(node)) {
-            for (const item of node) walk(item, scope);
-            return;
+            for (let index = 0; index < node.length; index += 1) {
+                node[index] = walk(node[index], scope);
+            }
+            return node;
         }
-        if (!isPlainObject(node)) return;
+        if (!isPlainObject(node)) return node;
 
         const childScope = extendScope(node, scope);
 
         for (const key of Object.keys(node)) {
+            // The declarations have been folded into the scope above and are
+            // of no further use; the default mode discards them as well.
+            if (isXmlnsAttr(key)) {
+                delete node[key];
+                continue;
+            }
+
             const colonIdx = key.indexOf(":");
             const ln = colonIdx === -1 ? key : key.slice(colonIdx + 1);
             const value = node[key];
@@ -332,18 +382,16 @@ function applyClarkNotation(root: unknown, attrPrefix: string): void {
             }
 
             if (ln === "prop") {
-                if (isPlainObject(value)) {
-                    node[actualKey] = rewritePropToClark(value, childScope);
-                } else if (Array.isArray(value)) {
-                    node[actualKey] = value.map(v =>
-                        isPlainObject(v) ? rewritePropToClark(v, childScope) : v
-                    );
-                }
+                node[actualKey] = Array.isArray(value)
+                    ? value.map(item => rewriteProp(item, childScope))
+                    : rewriteProp(value, childScope);
                 // Stop here; the prop content was rewritten in one shot.
             } else {
-                walk(value, childScope);
+                node[actualKey] = walk(value, childScope);
             }
         }
+
+        return Object.keys(node).length === 0 ? "" : node;
     }
 
     walk(root, EMPTY_SCOPE);
@@ -362,10 +410,15 @@ function applyClarkNotation(root: unknown, attrPrefix: string): void {
  *
  * The structural shape of `DAVResult` (`multistatus`/`response`/`propstat`/
  * `prop`/`status`/`href`) is unaffected by this option; only the keys
- * inside each `propstat.prop` change. Downstream helpers like
- * `prepareFileFromProps`, `parseStat` and `parseSearch` assume bare prop
- * keys and will not work with Clark-notation ones; consumers that opt in
- * are expected to address the Clark keys on their side.
+ * inside each `propstat.prop` change, and only for the direct children of
+ * `<prop>` (nested elements keep the prefix the server used). Downstream
+ * helpers like `prepareFileFromProps`, `parseStat` and `parseSearch` assume
+ * bare prop keys and will not work with Clark-notation ones; consumers that
+ * opt in are expected to address the Clark keys on their side.
+ *
+ * `context.tagParsers` and `context.attributeParsers` are unaffected as
+ * well: they are handed the same jPaths, without namespace prefixes, and
+ * are not invoked for the xmlns declarations in either mode.
  *
  * @param xml The raw XML string
  * @param context The current client context

--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -35,6 +35,7 @@ function toJPathString(
 function getParser({
     attributeNamePrefix,
     attributeParsers,
+    clarkNotationProps,
     entityDecoder: entityDecoderOptions,
     tagParsers
 }: WebDAVParsingContext): XMLParser {
@@ -43,7 +44,7 @@ function getParser({
         attributeNamePrefix,
         textNodeName: "text",
         ignoreAttributes: false,
-        removeNSPrefix: true,
+        removeNSPrefix: !clarkNotationProps,
         jPath: false,
         numberParseOptions: {
             hex: true,
@@ -165,9 +166,222 @@ function normaliseResult(result: DAVResultRaw): DAVResult {
     return output as DAVResult;
 }
 
+// Structural keys of the WebDAV multistatus envelope (RFC 4918). When
+// `clarkNotationProps` is enabled the parser keeps namespace prefixes on
+// every tag, so these structural keys arrive prefixed (e.g. `d:multistatus`)
+// and have to be renamed back to their bare local name so the existing
+// `normaliseResult` continues to work and `DAVResult` keeps its shape.
+//
+// Keep this list in sync with the structural fields exposed on `DAVResult`,
+// `DAVResultResponse`, `DAVResultPropstatResponse`, `DAVResultStatusResponse`
+// and `DAVPropStat` in `source/types.ts`. If a new structural field is added
+// to those interfaces, it must be added here too or the prefixed variant
+// will leak through into the result.
+const STRUCTURAL_KEYS = new Set([
+    "multistatus",
+    "response",
+    "propstat",
+    "prop",
+    "status",
+    "href",
+    "responsedescription"
+]);
+
+function localName(key: string): string {
+    const colonIdx = key.indexOf(":");
+    return colonIdx === -1 ? key : key.slice(colonIdx + 1);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
- * Parse an XML response from a WebDAV service,
- *  converting it to an internal DAV result
+ * Transform a parsed (prefix-preserving) tree in place to:
+ *
+ *  1. Rename structural keys (`multistatus`/`response`/...) back to their
+ *     bare local names so `DAVResult`'s shape is preserved.
+ *  2. Rewrite every key inside each `<prop>` to Clark notation
+ *     `{namespaceURI}localName`, resolving the namespace from the xmlns
+ *     scope of the surrounding multistatus and from any inline
+ *     `xmlns="..."` declared on the property element itself. Wrapped values
+ *     of the form `{ "@xmlns": ..., text: "..." }` are unwrapped to just
+ *     their text content.
+ *
+ * Pre-computes the xmlns attribute keys once and extends the prefix scope
+ * map only when a node actually declares xmlns, so the walk stays close to
+ * a plain tree traversal in cost.
+ */
+function applyClarkNotation(root: unknown, attrPrefix: string): void {
+    if (!isPlainObject(root) && !Array.isArray(root)) return;
+
+    // Stable string references for the duration of the walk; lets V8
+    // inline-cache the property accesses against the same key shapes.
+    const xmlnsKey = `${attrPrefix}xmlns`;
+    const xmlnsPrefixedKey = `${xmlnsKey}:`;
+    const xmlnsPrefixedKeyLen = xmlnsPrefixedKey.length;
+    const TEXT_KEY = "text";
+    const EMPTY_SCOPE: Map<string, string> = new Map();
+
+    function isXmlnsAttr(key: string): boolean {
+        return (
+            key === xmlnsKey ||
+            (key.length > xmlnsPrefixedKeyLen && key.startsWith(xmlnsPrefixedKey))
+        );
+    }
+
+    // Return an extended scope if `obj` declares any xmlns; otherwise reuse
+    // the parent scope to avoid allocating a Map for every node.
+    function extendScope(
+        obj: Record<string, unknown>,
+        parent: Map<string, string>
+    ): Map<string, string> {
+        let scope: Map<string, string> | null = null;
+        for (const key of Object.keys(obj)) {
+            if (key === xmlnsKey) {
+                if (!scope) scope = new Map(parent);
+                scope.set("", obj[key] as string);
+            } else if (key.length > xmlnsPrefixedKeyLen && key.startsWith(xmlnsPrefixedKey)) {
+                if (!scope) scope = new Map(parent);
+                scope.set(key.slice(xmlnsPrefixedKeyLen), obj[key] as string);
+            }
+        }
+        return scope ?? parent;
+    }
+
+    function unwrapXmlnsWrappedValue(raw: unknown): unknown {
+        if (!isPlainObject(raw)) return raw;
+        const text = raw[TEXT_KEY];
+        // If the only non-text keys are xmlns attrs, the element is a simple
+        // text node with namespace metadata: extract the text directly.
+        let onlyXmlnsAndText = true;
+        for (const k of Object.keys(raw)) {
+            if (k === TEXT_KEY) continue;
+            if (!isXmlnsAttr(k)) {
+                onlyXmlnsAndText = false;
+                break;
+            }
+        }
+        if (onlyXmlnsAndText && text !== undefined) return text;
+        // Complex element: clone with xmlns attrs stripped, keep child content.
+        const out: Record<string, unknown> = {};
+        for (const k of Object.keys(raw)) {
+            if (!isXmlnsAttr(k)) out[k] = raw[k];
+        }
+        return out;
+    }
+
+    function emitClarkForChild(
+        rawKey: string,
+        rawValue: unknown,
+        scope: Map<string, string>,
+        out: Record<string, unknown>
+    ): void {
+        const colonIdx = rawKey.indexOf(":");
+        const prefix = colonIdx === -1 ? "" : rawKey.slice(0, colonIdx);
+        const local = colonIdx === -1 ? rawKey : rawKey.slice(colonIdx + 1);
+        // Unknown prefix falls back to the null namespace; that yields a bare
+        // `local` key rather than throwing or losing the data.
+        const scopeNs = scope.get(prefix) ?? "";
+
+        const assign = (ns: string, value: unknown): void => {
+            const key = ns ? `{${ns}}${local}` : local;
+            const existing = out[key];
+            if (existing === undefined) {
+                out[key] = value;
+            } else if (Array.isArray(existing)) {
+                existing.push(value);
+            } else {
+                out[key] = [existing, value];
+            }
+        };
+
+        if (Array.isArray(rawValue)) {
+            for (const item of rawValue) {
+                const itemNs =
+                    isPlainObject(item) && xmlnsKey in item ? (item[xmlnsKey] as string) : scopeNs;
+                assign(itemNs, unwrapXmlnsWrappedValue(item));
+            }
+            return;
+        }
+
+        const ns =
+            isPlainObject(rawValue) && xmlnsKey in rawValue
+                ? (rawValue[xmlnsKey] as string)
+                : scopeNs;
+        assign(ns, unwrapXmlnsWrappedValue(rawValue));
+    }
+
+    function rewritePropToClark(
+        propObj: Record<string, unknown>,
+        parentScope: Map<string, string>
+    ): Record<string, unknown> {
+        const scope = extendScope(propObj, parentScope);
+        const out: Record<string, unknown> = {};
+        for (const key of Object.keys(propObj)) {
+            if (isXmlnsAttr(key)) continue;
+            emitClarkForChild(key, propObj[key], scope, out);
+        }
+        return out;
+    }
+
+    function walk(node: unknown, scope: Map<string, string>): void {
+        if (Array.isArray(node)) {
+            for (const item of node) walk(item, scope);
+            return;
+        }
+        if (!isPlainObject(node)) return;
+
+        const childScope = extendScope(node, scope);
+
+        for (const key of Object.keys(node)) {
+            const ln = localName(key);
+            const value = node[key];
+
+            // Rename structural keys to bare local name.
+            let actualKey = key;
+            if (STRUCTURAL_KEYS.has(ln) && ln !== key) {
+                delete node[key];
+                node[ln] = value;
+                actualKey = ln;
+            }
+
+            if (ln === "prop") {
+                if (isPlainObject(value)) {
+                    node[actualKey] = rewritePropToClark(value, childScope);
+                } else if (Array.isArray(value)) {
+                    node[actualKey] = value.map(v =>
+                        isPlainObject(v) ? rewritePropToClark(v, childScope) : v
+                    );
+                }
+                // Stop here; the prop content was rewritten in one shot.
+            } else {
+                walk(value, childScope);
+            }
+        }
+    }
+
+    walk(root, EMPTY_SCOPE);
+}
+
+/**
+ * Parse an XML response from a WebDAV service, converting it to an internal
+ * DAV result.
+ *
+ * When `context.clarkNotationProps` is `true`, every property key inside
+ * each `propstat.prop` is rewritten to Clark notation
+ * `{namespaceURI}localName`. This lets consumers disambiguate properties
+ * that share a local name across different XML namespaces (RFC 4918) and
+ * uses a single canonical key per property regardless of how the server
+ * serialised the namespace (prefix or inline default xmlns).
+ *
+ * The structural shape of `DAVResult` (`multistatus`/`response`/`propstat`/
+ * `prop`/`status`/`href`) is unaffected by this option; only the keys
+ * inside each `propstat.prop` change. Downstream helpers like
+ * `prepareFileFromProps`, `parseStat` and `parseSearch` assume bare prop
+ * keys and will not work with Clark-notation ones; consumers that opt in
+ * are expected to address the Clark keys on their side.
+ *
  * @param xml The raw XML string
  * @param context The current client context
  * @returns A parsed and processed DAV result
@@ -181,6 +395,9 @@ export function parseXML(xml: string, context?: WebDAVParsingContext): Promise<D
     };
     return new Promise(resolve => {
         const result = getParser(context).parse(xml);
+        if (context.clarkNotationProps) {
+            applyClarkNotation(result, context.attributeNamePrefix ?? "@");
+        }
         resolve(normaliseResult(result));
     });
 }

--- a/source/types.ts
+++ b/source/types.ts
@@ -33,6 +33,12 @@ export interface CreateWriteStreamOptions extends WebDAVMethodOptions {
     overwrite?: boolean;
 }
 
+// The bare local names of the structural fields below (`multistatus`,
+// `response`, `propstat`, `prop`, `status`, `href`, `responsedescription`)
+// are mirrored in the `STRUCTURAL_KEYS` set in `tools/dav.ts`, which strips
+// any namespace prefixes from those keys when `clarkNotationProps` is
+// enabled. Keep both in sync.
+
 /** <propstat> as per http://www.webdav.org/specs/rfc2518.html#rfc.section.12.9.1.1 */
 interface DAVPropStat {
     prop: DAVResultResponseProps;
@@ -408,6 +414,7 @@ export interface WebDAVEntityDecoderOptions {
 export interface WebDAVParsingContext {
     attributeNamePrefix?: string;
     attributeParsers: WebDAVAttributeParser[];
+    clarkNotationProps?: boolean;
     entityDecoder?: WebDAVEntityDecoderOptions;
     tagParsers: WebDAVTagParser[];
 }

--- a/source/types.ts
+++ b/source/types.ts
@@ -414,6 +414,23 @@ export interface WebDAVEntityDecoderOptions {
 export interface WebDAVParsingContext {
     attributeNamePrefix?: string;
     attributeParsers: WebDAVAttributeParser[];
+    /**
+     * Rewrite every key inside `propstat.prop` to Clark notation
+     * (`{namespaceURI}localName`) instead of the bare local name.
+     *
+     * This is a low-level escape hatch for consumers calling the exported
+     * `parseXML` directly. It is deliberately not exposed through
+     * `WebDAVClientOptions`: every client method that parses a multistatus
+     * (`stat`, `getDirectoryContents`, `search`, `getQuota`) reads bare prop
+     * keys such as `getlastmodified` or `resourcetype` and would break if it
+     * were wired in there.
+     *
+     * Note that `tagParsers` and `attributeParsers` keep receiving jPaths
+     * without namespace prefixes (`propstat.prop.displayname`) regardless of
+     * this option.
+     *
+     * @default false
+     */
     clarkNotationProps?: boolean;
     entityDecoder?: WebDAVEntityDecoderOptions;
     tagParsers: WebDAVTagParser[];

--- a/test/node/tools/dav.spec.ts
+++ b/test/node/tools/dav.spec.ts
@@ -218,6 +218,44 @@ describe("parseXML", function () {
             ).to.equal("alice");
         });
 
+        it("resolves prefixed prop tags against the multistatus xmlns scope", async function () {
+            // The other clarkNotationProps test uses inline `xmlns="..."` on
+            // each prop element (Sabre's serialisation for custom namespaces);
+            // this test exercises the other path where the namespace is
+            // resolved from the prefix-to-URI map declared on the multistatus
+            // element. Nextcloud and similar servers serialise this way.
+            const prefixedXml = `<?xml version="1.0"?>
+<d:multistatus
+    xmlns:d="DAV:"
+    xmlns:oc="http://owncloud.org/ns"
+    xmlns:nc="http://nextcloud.org/ns">
+    <d:response>
+        <d:href>/file.txt</d:href>
+        <d:propstat>
+            <d:prop>
+                <d:displayname>file.txt</d:displayname>
+                <oc:permissions>RDNVW</oc:permissions>
+                <nc:has-preview>true</nc:has-preview>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+    </d:response>
+</d:multistatus>`;
+            const parsed = await parseXML(prefixedXml, {
+                attributeNamePrefix: "@",
+                attributeParsers: [],
+                clarkNotationProps: true,
+                tagParsers: []
+            });
+            const props = parsed.multistatus.response[0].propstat.prop as unknown as Record<
+                string,
+                string
+            >;
+            expect(props["{DAV:}displayname"]).to.equal("file.txt");
+            expect(props["{http://owncloud.org/ns}permissions"]).to.equal("RDNVW");
+            expect(props["{http://nextcloud.org/ns}has-preview"]).to.equal(true);
+        });
+
         it("falls back to the null namespace for prefixes that are not in scope", async function () {
             const xmlMalformed = `<?xml version="1.0"?>
 <d:multistatus xmlns:d="DAV:">

--- a/test/node/tools/dav.spec.ts
+++ b/test/node/tools/dav.spec.ts
@@ -150,6 +150,106 @@ describe("parseXML", function () {
         ]);
     });
 
+    describe("clarkNotationProps", function () {
+        // Two extensions reuse the local name `value` under different
+        // namespaces. We use the inline default-namespace serialisation
+        // (`xmlns="..."` on each element rather than a prefix) because that
+        // is what Go's `encoding/xml` produces for namespaces it has no
+        // registered prefix for — and what the OpenCloud server actually
+        // sends for custom-namespace properties.
+        const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+    <d:response>
+        <d:href>/file.txt</d:href>
+        <d:propstat>
+            <d:prop>
+                <d:displayname>file.txt</d:displayname>
+                <oc:permissions>RDNVW</oc:permissions>
+                <value xmlns="http://opencloud.eu/ns/extensions/com.example.project">PROJ-123</value>
+                <priority xmlns="http://opencloud.eu/ns/extensions/com.example.project">high</priority>
+                <value xmlns="http://opencloud.eu/ns/extensions/com.example.review">approved</value>
+                <reviewer xmlns="http://opencloud.eu/ns/extensions/com.example.review">alice</reviewer>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+    </d:response>
+</d:multistatus>`;
+
+        it("merges same-local-name props from different namespaces into one key by default", async function () {
+            const parsed = await parseXML(xml);
+            const props = parsed.multistatus.response[0].propstat.prop;
+            // The two `value` elements collapse to one `value` key; values
+            // are preserved as an array but their namespace origin is lost.
+            expect(props.value).to.deep.equal(["PROJ-123", "approved"]);
+            expect(props.displayname).to.equal("file.txt");
+        });
+
+        it("rewrites prop keys to Clark notation when clarkNotationProps is true", async function () {
+            const parsed = await parseXML(xml, {
+                attributeNamePrefix: "@",
+                attributeParsers: [],
+                clarkNotationProps: true,
+                tagParsers: []
+            });
+            // Structural envelope unchanged: bare keys, normalised array of responses.
+            expect(parsed.multistatus.response).to.have.length(1);
+            const propstat = parsed.multistatus.response[0].propstat;
+            expect(propstat.status).to.equal("HTTP/1.1 200 OK");
+
+            // Prop keys are in Clark notation. Standard DAV/oc props resolve
+            // their prefix against the xmlns scope from the multistatus root;
+            // inline-default-namespace props resolve from their own xmlns
+            // attribute. The two same-local-name `value` props now coexist
+            // as distinct Clark keys.
+            const props = propstat.prop as unknown as Record<string, string>;
+            expect(props["{DAV:}displayname"]).to.equal("file.txt");
+            expect(props["{http://owncloud.org/ns}permissions"]).to.equal("RDNVW");
+            expect(props["{http://opencloud.eu/ns/extensions/com.example.project}value"]).to.equal(
+                "PROJ-123"
+            );
+            expect(
+                props["{http://opencloud.eu/ns/extensions/com.example.project}priority"]
+            ).to.equal("high");
+            expect(props["{http://opencloud.eu/ns/extensions/com.example.review}value"]).to.equal(
+                "approved"
+            );
+            expect(
+                props["{http://opencloud.eu/ns/extensions/com.example.review}reviewer"]
+            ).to.equal("alice");
+        });
+
+        it("falls back to the null namespace for prefixes that are not in scope", async function () {
+            const xmlMalformed = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+    <d:response>
+        <d:href>/file.txt</d:href>
+        <d:propstat>
+            <d:prop>
+                <d:displayname>file.txt</d:displayname>
+                <x:lonely xmlns:d="DAV:">orphan</x:lonely>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+    </d:response>
+</d:multistatus>`;
+            const parsed = await parseXML(xmlMalformed, {
+                attributeNamePrefix: "@",
+                attributeParsers: [],
+                clarkNotationProps: true,
+                tagParsers: []
+            });
+            const props = parsed.multistatus.response[0].propstat.prop as unknown as Record<
+                string,
+                string
+            >;
+            // Known prefix (d:) resolves normally; unknown prefix (x:) has no
+            // URI in scope and falls back to the null namespace, yielding a
+            // bare local-name key rather than throwing or losing the data.
+            expect(props["{DAV:}displayname"]).to.equal("file.txt");
+            expect(props.lonely).to.equal("orphan");
+        });
+    });
+
     describe("entityDecoder", function () {
         it("parses XML with entities when entityDecoder is not set", async function () {
             const xml = `<?xml version="1.0"?>

--- a/test/node/tools/dav.spec.ts
+++ b/test/node/tools/dav.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { readFile } from "fs/promises";
-import { parseXML, type WebDAVEntityDecoderOptions } from "../../../source/index.js";
+import {
+    parseXML,
+    type WebDAVEntityDecoderOptions,
+    type WebDAVParsingContext
+} from "../../../source/index.js";
+import { displaynameTagParser } from "../../../source/tools/dav.js";
 
 describe("parseXML", function () {
     it("keeps numeric-looking displaynames", async function () {
@@ -151,6 +156,13 @@ describe("parseXML", function () {
     });
 
     describe("clarkNotationProps", function () {
+        const clarkContext = (): WebDAVParsingContext => ({
+            attributeNamePrefix: "@",
+            attributeParsers: [],
+            clarkNotationProps: true,
+            tagParsers: []
+        });
+
         // Two extensions reuse the local name `value` under different
         // namespaces. We use the inline default-namespace serialisation
         // (`xmlns="..."` on each element rather than a prefix) because that
@@ -185,12 +197,7 @@ describe("parseXML", function () {
         });
 
         it("rewrites prop keys to Clark notation when clarkNotationProps is true", async function () {
-            const parsed = await parseXML(xml, {
-                attributeNamePrefix: "@",
-                attributeParsers: [],
-                clarkNotationProps: true,
-                tagParsers: []
-            });
+            const parsed = await parseXML(xml, clarkContext());
             // Structural envelope unchanged: bare keys, normalised array of responses.
             expect(parsed.multistatus.response).to.have.length(1);
             const propstat = parsed.multistatus.response[0].propstat;
@@ -241,12 +248,7 @@ describe("parseXML", function () {
         </d:propstat>
     </d:response>
 </d:multistatus>`;
-            const parsed = await parseXML(prefixedXml, {
-                attributeNamePrefix: "@",
-                attributeParsers: [],
-                clarkNotationProps: true,
-                tagParsers: []
-            });
+            const parsed = await parseXML(prefixedXml, clarkContext());
             const props = parsed.multistatus.response[0].propstat.prop as unknown as Record<
                 string,
                 string
@@ -254,6 +256,188 @@ describe("parseXML", function () {
             expect(props["{DAV:}displayname"]).to.equal("file.txt");
             expect(props["{http://owncloud.org/ns}permissions"]).to.equal("RDNVW");
             expect(props["{http://nextcloud.org/ns}has-preview"]).to.equal(true);
+        });
+
+        it("collects repeated props of the same namespace under one Clark key", async function () {
+            const repeatedXml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+    <d:response>
+        <d:href>/file.txt</d:href>
+        <d:propstat>
+            <d:prop>
+                <value xmlns="http://opencloud.eu/ns/extensions/com.example.project">PROJ-123</value>
+                <value xmlns="http://opencloud.eu/ns/extensions/com.example.project">PROJ-456</value>
+                <value xmlns="http://opencloud.eu/ns/extensions/com.example.project">PROJ-789</value>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+    </d:response>
+</d:multistatus>`;
+            const parsed = await parseXML(repeatedXml, clarkContext());
+            const props = parsed.multistatus.response[0].propstat.prop as unknown as Record<
+                string,
+                string[]
+            >;
+            // Unlike the cross-namespace case these genuinely share one Clark
+            // key, so their values are collected into an array in document
+            // order rather than overwriting each other.
+            expect(
+                props["{http://opencloud.eu/ns/extensions/com.example.project}value"]
+            ).to.deep.equal(["PROJ-123", "PROJ-456", "PROJ-789"]);
+        });
+
+        it("merges different serialisations of one namespace into a single Clark key", async function () {
+            // The same namespace arrives three ways inside one <prop>: bound
+            // to two different prefixes and as an inline default xmlns. The
+            // parser keeps those as three distinct keys, so it is the walker
+            // that has to collect them rather than let the later ones
+            // overwrite the earlier ones.
+            const mixedXml = `<?xml version="1.0"?>
+<d:multistatus
+    xmlns:d="DAV:"
+    xmlns:p="http://opencloud.eu/ns/extensions/com.example.project"
+    xmlns:proj="http://opencloud.eu/ns/extensions/com.example.project">
+    <d:response>
+        <d:href>/file.txt</d:href>
+        <d:propstat>
+            <d:prop>
+                <p:value>PROJ-123</p:value>
+                <proj:value>PROJ-456</proj:value>
+                <value xmlns="http://opencloud.eu/ns/extensions/com.example.project">PROJ-789</value>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+    </d:response>
+</d:multistatus>`;
+            const parsed = await parseXML(mixedXml, clarkContext());
+            const props = parsed.multistatus.response[0].propstat.prop as unknown as Record<
+                string,
+                string[]
+            >;
+            expect(
+                props["{http://opencloud.eu/ns/extensions/com.example.project}value"]
+            ).to.deep.equal(["PROJ-123", "PROJ-456", "PROJ-789"]);
+            expect(Object.keys(props)).to.have.length(1);
+        });
+
+        it("resolves namespaces declared on the prop element itself", async function () {
+            const inlineXml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+    <d:response>
+        <d:href>/file.txt</d:href>
+        <d:propstat>
+            <d:prop>
+                <x:custom xmlns:x="http://example.com/ns">value</x:custom>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+    </d:response>
+</d:multistatus>`;
+            const parsed = await parseXML(inlineXml, clarkContext());
+            const props = parsed.multistatus.response[0].propstat.prop as unknown as Record<
+                string,
+                string
+            >;
+            // The prefix is bound on the property element rather than on the
+            // multistatus, so it has to be folded into the scope before the
+            // key is resolved.
+            expect(props["{http://example.com/ns}custom"]).to.equal("value");
+        });
+
+        it("leaves the envelope shape untouched", async function () {
+            const emptyXml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"/>`;
+            const clark = await parseXML(emptyXml, clarkContext());
+            // The namespace declarations are consumed by the walker, so an
+            // empty multistatus stays empty instead of being mistaken for a
+            // response with props.
+            expect(clark).to.deep.equal(await parseXML(emptyXml));
+            expect(clark.multistatus.response).to.deep.equal([]);
+
+            const parsed = await parseXML(xml, clarkContext());
+            expect(Object.keys(parsed.multistatus)).to.deep.equal(["response"]);
+            expect(Object.keys(parsed.multistatus.response[0])).to.deep.equal(["href", "propstat"]);
+        });
+
+        it("keeps empty and structured prop values in their default shape", async function () {
+            const shapesXml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+    <d:response>
+        <d:href>/dir</d:href>
+        <d:propstat>
+            <d:prop>
+                <oc:favorite/>
+                <marker xmlns="http://example.com/ns"/>
+                <d:resourcetype><d:collection/></d:resourcetype>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+    </d:response>
+</d:multistatus>`;
+            const parsed = await parseXML(shapesXml, clarkContext());
+            const props = parsed.multistatus.response[0].propstat.prop as unknown as Record<
+                string,
+                unknown
+            >;
+            expect(props["{http://owncloud.org/ns}favorite"]).to.equal("");
+            expect(props["{http://example.com/ns}marker"]).to.equal("");
+            // Only the direct children of <prop> are rewritten, so nested
+            // elements keep the prefix the server serialised them with.
+            expect(props["{DAV:}resourcetype"]).to.deep.equal({ "d:collection": "" });
+        });
+
+        it("passes unprefixed jPaths to tag and attribute parsers", async function () {
+            const dottedPrefixXml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:my.ns="http://example.com/ns">
+    <d:response>
+        <d:href>/file.txt</d:href>
+        <d:propstat>
+            <d:prop>
+                <d:displayname>2024.10</d:displayname>
+                <my.ns:tag my.ns:id="007">secret</my.ns:tag>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+    </d:response>
+</d:multistatus>`;
+            const parseRecording = async (clarkNotationProps: boolean) => {
+                const tags: string[] = [];
+                const attributes: string[] = [];
+                const parsed = await parseXML(dottedPrefixXml, {
+                    attributeNamePrefix: "@",
+                    clarkNotationProps,
+                    attributeParsers: [
+                        (jPath, value) => {
+                            attributes.push(jPath);
+                            return value;
+                        }
+                    ],
+                    tagParsers: [
+                        (jPath, value) => {
+                            tags.push(jPath);
+                            return value;
+                        },
+                        displaynameTagParser
+                    ]
+                });
+                return { attributes, parsed, tags };
+            };
+            const clark = await parseRecording(true);
+            const plain = await parseRecording(false);
+            // Prefixes are stripped per path segment, so a prefix containing a
+            // dot cannot be mistaken for a segment boundary, and the xmlns
+            // declarations Clark mode retains never reach the parsers either.
+            expect(clark.tags).to.deep.equal(plain.tags);
+            expect(clark.attributes).to.deep.equal(plain.attributes);
+            expect(clark.tags).to.include("multistatus.response.propstat.prop.displayname");
+            expect(clark.attributes).to.include("multistatus.response.propstat.prop.tag");
+            const props = clark.parsed.multistatus.response[0].propstat.prop as unknown as Record<
+                string,
+                string
+            >;
+            // The built-in displayname parser matched, so the value was not
+            // interpreted as the number 2024.1.
+            expect(props["{DAV:}displayname"]).to.equal("2024.10");
         });
 
         it("falls back to the null namespace for prefixes that are not in scope", async function () {
@@ -270,12 +454,7 @@ describe("parseXML", function () {
         </d:propstat>
     </d:response>
 </d:multistatus>`;
-            const parsed = await parseXML(xmlMalformed, {
-                attributeNamePrefix: "@",
-                attributeParsers: [],
-                clarkNotationProps: true,
-                tagParsers: []
-            });
+            const parsed = await parseXML(xmlMalformed, clarkContext());
             const props = parsed.multistatus.response[0].propstat.prop as unknown as Record<
                 string,
                 string


### PR DESCRIPTION
Related to #210, though not a full fix for the high-level `stat()` shape it asks about.

## Motivation

I'm building a generic extension metadata mechanism in OpenCloud. Third-party extensions can attach typed metadata to files, and the natural mapping for cross-protocol access turned out to be one custom XML namespace per extension. Multiple extensions can then reuse the same local property name without colliding, because the namespace URI is what disambiguates them. RFC 4918 supports this cleanly, and on the server side it falls out for free.

On the client side it doesn't. Today `parseXML` strips namespace prefixes unconditionally, so two properties with the same local name from different namespaces (e.g. `<value xmlns="proj-ns">` and `<value xmlns="rev-ns">`) collapse to a single `value` key (with values merged into an array) and lose their namespace origin entirely. Real-world servers add a second twist: Go's `encoding/xml` and similar marshalers serialise the standard DAV/oc properties with prefixes (`<d:getlastmodified>`) but custom-namespace properties with **inline default xmlns** on the element (`<value xmlns="...">`), because they have no prefix registered for the custom namespace. The client has to deal with both serialisation styles in the same response.

## What I originally tried

My first attempt at this PR was a simple opt-in that just told `parseXML` to keep namespace prefixes on tags (essentially `removeNSPrefix: false`). That works for servers that prefix-serialise custom namespaces, but for the inline-`xmlns` style it just leaked fast-xml-parser's raw object shape into the result (`{ "text": "...", "@xmlns": "..." }` per element, arrays when collisions occur, and so on). That made the option's output awkward to reason about and inconsistent across server serialisation styles. I'd be shipping a half-feature whose consumers would commit to an unpleasant shape, and any "real" fix later would mean a second parallel opt-in.

So the actual feature is Clark notation: one canonical key per property regardless of how the server expressed the namespace.

## What this PR does

Adds an optional `clarkNotationProps` field to `WebDAVParsingContext`, defaulting to `false`. When set to `true`, every property key inside each `propstat.prop` is rewritten to Clark notation `{namespaceURI}localName`. The structural shape of `DAVResult` is unaffected: `multistatus`, `response`, `propstat`, `prop`, `status`, `href` all keep their bare names, and the existing `normaliseResult` runs unchanged.

Downstream helpers like `prepareFileFromProps`, `parseStat` and `parseSearch` assume bare prop keys and are intentionally left untouched; consumers that opt in handle the Clark-notation keys on their side, which is a single property access if they know the namespace they're after.

## Implementation notes

The implementation isn't completely trivial and I'd really appreciate review feedback. A single-pass tree walker runs after `fast-xml-parser` parses with `removeNSPrefix: false` and does two things in one traversal:

1. Renames any prefixed structural keys back to their bare local names so `normaliseResult` can do its job.
2. Inside each `<prop>`, walks the children, resolves each one's namespace (from the xmlns scope of the multistatus element, or from an inline `xmlns="..."` on the element itself), unwraps the `{ text, "@xmlns" }` object shape, and emits a single Clark-notation key per property. Same-local-name collisions in different namespaces become distinct keys.

Edge cases:
- Unknown prefixes (used but never declared) fall back to the null namespace; that yields a bare local-name key instead of throwing.
- Multiple elements with the same Clark key (genuine collisions in the same namespace) are kept as an array under that key.
- The walk extends the prefix-to-URI scope map only when a node actually declares xmlns, to avoid per-node allocations.
- String references for the xmlns/text attribute keys are computed once at the start of the walk so V8 can inline-cache the hot lookups.

I tried to keep the cost as low as I could by benchmarking alternative walker designs (V8 micro-optimisations, algorithmic restructure with direct navigation of the envelope, and parser-cooperative approaches using fast-xml-parser hooks). The full benchmark suite landed within noise of the current shape on end-to-end `parseXML`, since the parser dominates the cost and the walker is a small slice on top. I left the walker as a clean generic traversal rather than commit a more complex variant for a wash result. Very open to suggestions if you see a cheaper structural pattern.

## Performance

Benchmarked against the current default and a discarded two-pass alternative. Each benchmark fixture is a synthetic multistatus response: one `<d:response>` per file with a single `<d:propstat>` (status 200) containing 8 standard properties (`d:getlastmodified`, `d:getcontentlength`, `d:getetag`, `d:getcontenttype`, `d:resourcetype`, `oc:permissions`, `oc:id`, `oc:fileid`) plus additional extension properties from two distinct custom namespaces with inline default-xmlns serialisation (the realistic Sabre / Go-`encoding/xml` shape), rotating, up to the configured prop count per file.

| scenario | size | default (strip) | clarkNotationProps | overhead |
|---|---:|---:|---:|---:|
| 10 files / 10 props | 8.5 KB | 0.38 ms | 0.41 ms | +6% |
| 100 files / 15 props | 134 KB | 4.96 ms | 5.96 ms | +20% |
| 1k files / 20 props | 1.8 MB | 69 ms | 84 ms | +21% |
| 5k files / 30 props | 14 MB | 514 ms | 640 ms | +24% |
| 10k files / 50 props | 49 MB | 1674 ms | 2125 ms | +27% |
| 20k files / 50 props | 99 MB | 3343 ms | 4279 ms | +28% |

Overhead settles around 25% on realistic-and-large inputs, paid only by consumers that opt in.

## Tests

Three cases under `parseXML > clarkNotationProps`: documents today's collapse-on-collision behaviour (lossy array of values), verifies that the Clark-notation rewrite yields distinct canonical keys covering both prefix-resolved (DAV/oc) and inline-xmlns (extension) properties, and a malformed-input case where an undeclared prefix falls back to the null namespace rather than crashing.