### PR TITLE
fix: declare @nodable/entities as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@buttercup/fetch": "^0.2.1",
+        "@nodable/entities": "^2.2.0",
         "base-64": "^1.0.0",
         "byte-length": "^1.0.2",
         "entities": "^6.0.1",
@@ -2330,9 +2331,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -9846,9 +9847,9 @@
       }
     },
     "@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="
     },
     "@open-draft/deferred-promise": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "homepage": "https://github.com/perry-mitchell/webdav-client#readme",
   "dependencies": {
     "@buttercup/fetch": "^0.2.1",
+    "@nodable/entities": "^2.2.0",
     "base-64": "^1.0.0",
     "byte-length": "^1.0.2",
     "entities": "^6.0.1",


### PR DESCRIPTION
`tools/dav.ts` imports `EntityDecoder` from `@nodable/entities`, but the package was never declared in dependencies. Under strict `node_modules` layouts (e.g. pnpm) the import fails to resolve with:

```
Cannot find package '@nodable/entities' imported from webdav/dist/node/tools/dav.js
```

Hence declare it explicitly (`^2.2.0`, matching `fast-xml-parser`).