### PR TITLE
feat: export displaynameTagParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,16 +259,30 @@ const client = createClient("https://some-server.org", {
 Property keys are reported by their local name, so two properties sharing a local name across different XML namespaces collapse into one key. Passing `clarkNotationProps` to the exported `parseXML` keys them in [Clark notation](http://www.jclark.com/xml/xmlns.htm) (`{namespaceURI}localName`) instead, which keeps them apart and gives a property the same key regardless of whether the server used a prefix or an inline `xmlns`:
 
 ```typescript
-import { parseXML } from "webdav";
+import { displaynameTagParser, parseXML } from "webdav";
 
 const result = await parseXML(xml, {
     attributeNamePrefix: "@",
     attributeParsers: [],
     clarkNotationProps: true,
-    tagParsers: []
+    tagParsers: [displaynameTagParser]
 });
 // { "{DAV:}displayname": "file.txt", "{http://owncloud.org/ns}permissions": "RDNVW" }
 const props = result.multistatus.response[0].propstat.prop;
+```
+
+A context replaces the default parsers instead of extending them, so anything it does not list is gone. `displaynameTagParser` is the one applied by default, and it is exported for exactly this reason: without it in the list, a displayname like `2024.10` is read as the number `2024.1`. Own parsers are appended to it:
+
+```typescript
+// Keep a custom property verbatim, but leave the defaults in place.
+function tokenTagParser(jPath: string, value: string) {
+    if (jPath.endsWith("prop.token")) {
+        return; // use the text as it is
+    }
+    return value; // apply default parsing
+}
+
+tagParsers: [displaynameTagParser, tokenTagParser];
 ```
 
 This is a low-level option for consumers parsing responses themselves: it is not available on `createClient`, as the client methods (`stat`, `getDirectoryContents`, `search`, `getQuota`) read bare property keys. Only the direct children of `<prop>` are rewritten, and a property whose prefix has no namespace declaration in scope keeps its bare local name.

--- a/source/index.ts
+++ b/source/index.ts
@@ -2,6 +2,12 @@ export { createClient } from "./factory.js";
 export { getPatcher } from "./compat/patcher.js";
 export * from "./types.js";
 
-export { parseStat, parseXML, translateDiskSpace, prepareFileFromProps } from "./tools/dav.js";
+export {
+    displaynameTagParser,
+    parseStat,
+    parseXML,
+    translateDiskSpace,
+    prepareFileFromProps
+} from "./tools/dav.js";
 export { calculateDataLength } from "./tools/size.js";
 export { processResponsePayload } from "./response.js";

--- a/source/tools/dav.ts
+++ b/source/tools/dav.ts
@@ -115,6 +115,9 @@ function getParser({
 /**
  * Tag parser for the displayname prop.
  * Ensure that the displayname is not parsed and always handled as is.
+ * Applied by default, but a `context` passed to `parseXML` replaces the
+ * default parsers wholesale, so it has to be listed in that context's
+ * `tagParsers` again to keep the behaviour.
  * @param path The jPath of the tag
  * @param value The text value of the tag
  */

--- a/test/node/tools/dav.spec.ts
+++ b/test/node/tools/dav.spec.ts
@@ -18,18 +18,38 @@ describe("parseXML", function () {
         expect(parsed.multistatus.response[0].propstat.prop.displayname).to.equal("2024.10");
     });
 
-    it("keeps numeric-looking displaynames with a custom context", async function () {
-        const data = await readFile(
-            new URL("../../responses/propfind-float-like-displayname.xml", import.meta.url)
-        );
-        // A context replaces the default parsers, so the exported parser has to
-        // be listed again to keep the trailing zero.
-        const parsed = await parseXML(data.toString(), {
-            attributeNamePrefix: "@",
-            attributeParsers: [],
-            tagParsers: [displaynameTagParser]
+    describe("with a custom parsing context", function () {
+        const parseWith = async (tagParsers: WebDAVParsingContext["tagParsers"]) => {
+            const data = await readFile(
+                new URL("../../responses/propfind-float-like-displayname.xml", import.meta.url)
+            );
+            const parsed = await parseXML(data.toString(), {
+                attributeNamePrefix: "@",
+                attributeParsers: [],
+                tagParsers
+            });
+            return parsed.multistatus.response[0].propstat.prop.displayname;
+        };
+
+        it("drops the default parsers the context does not list", async function () {
+            // A context replaces the defaults rather than extending them, which
+            // is why the parser has to be reachable from outside at all.
+            expect(await parseWith([])).to.equal(2024.1);
         });
-        expect(parsed.multistatus.response[0].propstat.prop.displayname).to.equal("2024.10");
+
+        it("keeps displaynames intact when the exported parser is listed", async function () {
+            expect(await parseWith([displaynameTagParser])).to.equal("2024.10");
+        });
+
+        it("applies own parsers alongside it", async function () {
+            const upperCaseParser = (jPath: string, value: string) =>
+                jPath.endsWith("prop.displayname") ? value : value.toString().toUpperCase();
+
+            // The first parser to return something other than the value it was
+            // given wins, so order decides: displayname stays a string, the
+            // other props go through the second parser.
+            expect(await parseWith([displaynameTagParser, upperCaseParser])).to.equal("2024.10");
+        });
     });
 
     it("correctly parses property attributes", async function () {

--- a/test/node/tools/dav.spec.ts
+++ b/test/node/tools/dav.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { readFile } from "fs/promises";
 import {
+    displaynameTagParser,
     parseXML,
     type WebDAVEntityDecoderOptions,
     type WebDAVParsingContext
 } from "../../../source/index.js";
-import { displaynameTagParser } from "../../../source/tools/dav.js";
 
 describe("parseXML", function () {
     it("keeps numeric-looking displaynames", async function () {
@@ -15,6 +15,20 @@ describe("parseXML", function () {
         const parsed = await parseXML(data.toString());
         expect(parsed.multistatus.response).to.have.length(1);
         // Ensure trailing zero is not lost
+        expect(parsed.multistatus.response[0].propstat.prop.displayname).to.equal("2024.10");
+    });
+
+    it("keeps numeric-looking displaynames with a custom context", async function () {
+        const data = await readFile(
+            new URL("../../responses/propfind-float-like-displayname.xml", import.meta.url)
+        );
+        // A context replaces the default parsers, so the exported parser has to
+        // be listed again to keep the trailing zero.
+        const parsed = await parseXML(data.toString(), {
+            attributeNamePrefix: "@",
+            attributeParsers: [],
+            tagParsers: [displaynameTagParser]
+        });
         expect(parsed.multistatus.response[0].propstat.prop.displayname).to.equal("2024.10");
     });
 


### PR DESCRIPTION
Follow-up to #410.

`parseXML(xml, context)` replaces the default tag parsers instead of extending them, so a consumer that passes a context (e.g. to set `clarkNotationProps`) silently loses the displayname protection and cannot put it back, because the parser is not exported. The example #410 added to the README walks straight into this: it passes `tagParsers: []`.

- exports `displaynameTagParser` and notes the replacement behaviour in its JSDoc
- fixes the README example and shows how an own parser is appended to the default
- tests all three cases: no parsers (`2024.10` becomes the number `2024.1`), the exported parser listed, and an own parser next to it

Draft because I ran into this while wiring #410 up on the consumer side; happy to fold it into something else if you would rather not grow the public surface.